### PR TITLE
Fix issue where introduction counter is not reset

### DIFF
--- a/assets/book/styles/components/structure/_numbering.scss
+++ b/assets/book/styles/components/structure/_numbering.scss
@@ -44,17 +44,26 @@ div.front-matter {
   &.introduction {
     page: introduction;
     prince-page-group: start;
+    counter-reset: page 1;
   }
 }
 
 div.part {
   page: part;
   prince-page-group: start;
+
+  &.introduction {
+    counter-reset: page 1;
+  }
 }
 
 div.chapter {
   page: chapter;
   prince-page-group: start;
+
+  &.introduction {
+    counter-reset: page 1;
+  }
 }
 
 div.back-matter {
@@ -65,12 +74,6 @@ div.back-matter {
 div.blank-page {
   page: blank-page;
   prince-page-group: start;
-}
-
-// Page 1 Counter Reset
-
-div.introduction {
-  counter-reset: page 1;
 }
 
 // PDF Bookmark levels


### PR DESCRIPTION
The `.introduction` class is added to the first item in the book, which is sometimes front matter, sometimes parts, and sometimes chapters. The counter reset was not properly applying to parts. This PR should fix it.