### PR TITLE
Update Buckram to 0.7.1, fix author string for legacy themes

### DIFF
--- a/assets/book/styles/buckram.scss
+++ b/assets/book/styles/buckram.scss
@@ -1,5 +1,5 @@
 /*
  * Name: Buckram
- * Version: 0.7.0
+ * Version: 0.7.1
  * Description: Opinionated SCSS components for books (web, EPUB and PDF).
  */

--- a/assets/book/styles/components/structure/_content-strings.scss
+++ b/assets/book/styles/components/structure/_content-strings.scss
@@ -20,7 +20,7 @@ meta[name="pb-subtitle"] {
   string-set: book-subtitle attr('content');
 }
 
-meta[name="pb-author"] {
+meta[name="pb-authors"] {
   string-set: book-author attr('content');
 }
 

--- a/assets/legacy/styles/_pdf-house-style.scss
+++ b/assets/legacy/styles/_pdf-house-style.scss
@@ -742,7 +742,7 @@ meta[name="pb-subtitle"] {
   string-set: book-subtitle attr('content');
 }
 
-meta[name="pb-author"] {
+meta[name="pb-authors"] {
   string-set: book-author attr('content');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,9 +1962,9 @@
       "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
     },
     "buckram": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/buckram/-/buckram-0.7.0.tgz",
-      "integrity": "sha512-PRK/mA7yaTPEQbkoC8+PkMrHxWMVkjG0EwoS856AHO0MrniQzNv3PqQm0ypxXOAkvPQOGWUco6g4wyEo7UL+7g=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/buckram/-/buckram-0.7.1.tgz",
+      "integrity": "sha512-V0Fa2xwMzqeXRU8BAsoM7zxammVCPRm9cSYsKjn4R6Ps4TVdZ1Wa4zWVrUUVpaxr9se0yxSFApIPMlyvYKAy6g=="
     },
     "buffer": {
       "version": "4.9.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@pressbooks/pressbooks-book",
-	"description":
-		"This theme is named after Canadian media theorist Marshall McLuhan, who coined the phrase “the medium is the message.” It is designed for academic writing and is also suitable for fiction. Headings are set in Cormorant Garamond, and body type is set in Lora.",
+	"description": "This theme is named after Canadian media theorist Marshall McLuhan, who coined the phrase “the medium is the message.” It is designed for academic writing and is also suitable for fiction. Headings are set in Cormorant Garamond, and body type is set in Lora.",
 	"author": "Pressbooks (Book Oven Inc.)",
 	"license": "GPL-3.0-or-later",
 	"engines": {
@@ -13,7 +12,7 @@
 	},
 	"dependencies": {
 		"aetna": "^1.0.0-alpha.17",
-		"buckram": "^0.7.0",
+		"buckram": "^0.7.1",
 		"js-cookie": "^2.2.0",
 		"sharer.js": "^0.3.1"
 	},
@@ -21,18 +20,13 @@
 		"pressbooks-build-tools": "^0.11.0"
 	},
 	"scripts": {
-		"build":
-			"cross-env NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-		"build:production":
-			"cross-env NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-		"start":
-			"cross-env NODE_ENV=development webpack --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+		"build": "cross-env NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+		"build:production": "cross-env NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+		"start": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
 		"rmdist": "rimraf dist",
 		"lint": "npm run -s lint:scripts && npm run -s lint:styles",
-		"lint:scripts":
-			"node_modules/eslint/bin/eslint.js \"assets/src/scripts/*.js\"",
-		"lint:styles":
-			"node_modules/stylelint/bin/stylelint.js \"assets/src/styles/**/*.scss\" \"assets/styles/**/*.scss\" --syntax scss",
+		"lint:scripts": "node_modules/eslint/bin/eslint.js \"assets/src/scripts/*.js\"",
+		"lint:styles": "node_modules/stylelint/bin/stylelint.js \"assets/src/styles/**/*.scss\" \"assets/styles/**/*.scss\" --syntax scss",
 		"test": "npm run -s lint"
 	},
 	"eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,9 +1383,9 @@ bs-recipes@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/bs-recipes/-/bs-recipes-1.3.4.tgz#0d2d4d48a718c8c044769fdc4f89592dc8b69585"
 
-buckram@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/buckram/-/buckram-0.7.0.tgz#a9028f3575c1f702851946bb7db9eed775f5d26c"
+buckram@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/buckram/-/buckram-0.7.1.tgz#0173eb9e77e28bc707ae9a9a43e4364a09ed6de2"
 
 buffer-crc32@~0.2.3:
   version "0.2.13"


### PR DESCRIPTION
Fixes an issue where book authors were not appearing in running content.