### PR TITLE
Use $post_id instead of $slug when calling pb_get_chapter_number()

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -21,7 +21,7 @@ function toc_sections( $sections, $post_type, $can_read, $can_read_private, $per
 			<div class="inner-content">
 			<?php } ?>
 				<a class="toc__chapter-title" href="<?php echo get_permalink( $section['ID'] ); ?>">
-					<?php $chapter_number = pb_get_chapter_number( $section['post_name'] );
+					<?php $chapter_number = pb_get_chapter_number( $section['ID'] );
 					if ( $chapter_number ) {
 						echo "<span>$chapter_number.&nbsp;</span>";
 					}

--- a/single.php
+++ b/single.php
@@ -4,7 +4,7 @@
 		get_header();
 		if ( pb_is_public() ) :
 			$web_options = get_option( 'pressbooks_theme_options_web' );
-			$number = ( $post->post_type === 'chapter' ) ? pb_get_chapter_number( $post->post_name ) : false;
+			$number = ( $post->post_type === 'chapter' ) ? pb_get_chapter_number( $post->ID ) : false;
 			$subtitle = get_post_meta( $post->ID, 'pb_subtitle', true );
 			$contributors = new \Pressbooks\Contributors();
 			$authors = $contributors->get( $post->ID, 'authors' );


### PR DESCRIPTION
Depends on https://github.com/pressbooks/pressbooks/pull/1165

Related to
https://github.com/pressbooks/pressbooks-book/issues/151