### PR TITLE
Fix TOC caching

### DIFF
--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -4,12 +4,19 @@ namespace Pressbooks\Book\Actions;
 
 /**
  * Delete the cached Table of Contents.
+ *
+ * @see partials/content-toc.php
  */
 function delete_cached_contents() {
-	global $wpdb;
-	$results = $wpdb->get_results( "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE ('_transient_pb_book_contents%')" );
-	foreach ( $results as $val ) {
-		$transient = str_replace( '_transient_', '', $val->option_name );
+	$bits = 3;
+	$max = ( 1 << $bits );
+	$transients = [];
+	for ( $i = 0; $i < $max; $i++ ) {
+		$t = str_pad( decbin( $i ), $bits, '0', STR_PAD_LEFT );
+		$t = str_replace( [ 1, 0 ], [ 'x', 'o' ], $t );
+		$transients[] = "pb_book_contents_{$t}";
+	}
+	foreach ( $transients as $transient ) {
 		delete_transient( $transient );
 	}
 }

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -2,7 +2,7 @@
 
 namespace Pressbooks\Book\Helpers;
 
-function toc_sections( $sections, $post_type, $can_read, $can_read_private, $permissive_private_content, $should_parse_subsections ) {
+function toc_sections( $sections, $post_type, $can_read, $can_read_private, $permissive_private_content ) {
 	foreach ( $sections as $section ) {
 		if ( ! in_array( $section['post_status'], [ 'publish', 'web-only' ], true ) ) {
 			if ( ! $can_read_private ) {
@@ -26,7 +26,7 @@ function toc_sections( $sections, $post_type, $can_read, $can_read_private, $per
 					}
 					echo pb_strip_br( $section['post_title'] ); ?>
 				</a>
-				<?php if ( $should_parse_subsections ) {
+				<?php if ( pb_should_parse_subsections() ) {
 					$subsections = pb_get_subsections( $section['ID'] );
 					if ( $subsections ) { ?>
 						<ol class="toc__subsections">

--- a/partials/content-toc.php
+++ b/partials/content-toc.php
@@ -9,7 +9,6 @@ global $blog_id;
 $can_read = current_user_can_for_blog( $blog_id, 'read' );
 $can_read_private = current_user_can_for_blog( $blog_id, 'read_private_posts' );
 $permissive_private_content = (int) get_option( 'permissive_private_content', 0 );
-$should_parse_subsections = pb_should_parse_subsections();
 $toc_chmod = ( $can_read ? 'x' : 'o' ) . ( $can_read_private ? 'x' : 'o' ) . ( $permissive_private_content ? 'x' : 'o' );
 $toc_transient = 'pb_book_contents_' . $toc_chmod;
 $toc_output = get_transient( $toc_transient );
@@ -21,7 +20,7 @@ if ( ! $toc_output ) {
 	<ol class="toc toc__list">
 		<li id="toc-front-matter" class="dropdown">
 			<h3 class="toc__front-matter__title"><?php _e( 'Front Matter', 'pressbooks' ); ?></h3>
-			<ol class="toc__front-matter-list"><?php \Pressbooks\Book\Helpers\toc_sections( $book_structure['front-matter'], 'front-matter', $can_read, $can_read_private, $permissive_private_content, $should_parse_subsections ); ?></ol>
+			<ol class="toc__front-matter-list"><?php \Pressbooks\Book\Helpers\toc_sections( $book_structure['front-matter'], 'front-matter', $can_read, $can_read_private, $permissive_private_content ); ?></ol>
 		</li>
 		<?php
 		$n = 0;
@@ -40,13 +39,13 @@ if ( ! $toc_output ) {
 					</h3><?php }
 				if ( ! empty( $part['chapters'] ) ) { ?>
 					<div class="inner-content">
-						<ol class="toc__chapters"><?php \Pressbooks\Book\Helpers\toc_sections( $part['chapters'], 'chapter', $can_read, $can_read_private, $permissive_private_content, $should_parse_subsections ); ?></ol>
+						<ol class="toc__chapters"><?php \Pressbooks\Book\Helpers\toc_sections( $part['chapters'], 'chapter', $can_read, $can_read_private, $permissive_private_content ); ?></ol>
 					</div>
 				<?php } ?></li><?php }
 		endforeach; ?>
 		<li id="toc-back-matter" class="dropdown">
 			<h3 class="toc__back-matter__title"><?php _e( 'Back Matter', 'pressbooks' ); ?></h3>
-			<ol class="toc__back-matter-list"><?php \Pressbooks\Book\Helpers\toc_sections( $book_structure['back-matter'], 'back-matter', $can_read, $can_read_private, $permissive_private_content, $should_parse_subsections ); ?></ol>
+			<ol class="toc__back-matter-list"><?php \Pressbooks\Book\Helpers\toc_sections( $book_structure['back-matter'], 'back-matter', $can_read, $can_read_private, $permissive_private_content ); ?></ol>
 		</li>
 	</ol><!-- end #toc -->
 


### PR DESCRIPTION
When using redis (or memcached) transients are not in the database so querying for them in the DB was returning nothing.

The fix is to delete every combination of the transient for good measure.