### PR TITLE
Add front/back matter types to navigation (fixes pressbooks/pressbooks#1311)

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -2,6 +2,7 @@
 
 namespace Pressbooks\Book\Helpers;
 
+use function \Pressbooks\PostType\get_post_type_label;
 use Pressbooks\Container;
 
 /**
@@ -422,29 +423,49 @@ function get_links( $echo = true ) {
 	$first_chapter          = pb_get_first();
 	$prev_chapter           = pb_get_prev();
 	$prev_chapter_id        = pb_get_prev_post_id();
-	$prev_chapter_post_type = \Pressbooks\PostType\get_post_type_label( get_post_type( $prev_chapter_id ) );
+	$prev_post_type         = get_post_type( $prev_chapter_id );
+	if ( in_array( $prev_post_type, [ 'front-matter', 'back-matter', 'chapter' ], true ) ) {
+		$prev_section_type = pb_get_section_type( get_post( $prev_chapter_id ) );
+		if ( in_array( $prev_section_type, [ 'miscellaneous', 'standard', 'numberless' ], true ) ) {
+			$prev_label = get_post_type_label( $prev_post_type );
+		} else {
+			$prev_label = get_term_by( 'slug', $prev_section_type, "$prev_post_type-type" )->name;
+		}
+	} else {
+		$prev_label = get_post_type_label( $prev_post_type );
+	}
 	$next_chapter           = pb_get_next();
 	$next_chapter_id        = pb_get_next_post_id();
-	$next_chapter_post_type = \Pressbooks\PostType\get_post_type_label( get_post_type( $next_chapter_id ) );
+	$next_post_type         = get_post_type( $next_chapter_id );
+	if ( in_array( $next_post_type, [ 'front-matter', 'back-matter', 'chapter' ], true ) ) {
+		$next_section_type = pb_get_section_type( get_post( $next_chapter_id ) );
+		if ( in_array( $next_section_type, [ 'miscellaneous', 'standard', 'numberless' ], true ) ) {
+			$next_label = get_post_type_label( $next_post_type );
+		} else {
+			$next_label = get_term_by( 'slug', $next_section_type, "$next_post_type-type" )->name;
+		}
+	} else {
+		$next_label = get_post_type_label( $next_post_type );
+	}
 	if ( $echo ) :
 		?>
 		<nav class="nav-reading <?php echo $multipage ? 'nav-reading--multipage' : '' ?>" role="navigation">
 		<div class="nav-reading__previous js-nav-previous">
 			<?php if ( $prev_chapter !== '/' ) { ?>
 				<?php /* translators: %1$s: post title, %2$s: post type name */ ?>
-				<a href="<?php echo $prev_chapter; ?>" title="<?php printf( __( 'Previous: %1$s (%2$s)', 'pressbooks-book' ), get_the_title( $prev_chapter_id ), $prev_chapter_post_type ); ?>">
+				<a href="<?php echo $prev_chapter; ?>" title="<?php printf( __( 'Previous: %1$s (%2$s)', 'pressbooks-book' ), get_the_title( $prev_chapter_id ), $prev_label ); ?>">
 					<svg class="icon--svg"><use xlink:href="#arrow-left" /></svg>
 					<?php /* translators: %s: post type name */ ?>
-					<?php printf( __( 'Previous (%s)', 'pressbooks-book' ), $prev_chapter_post_type ); ?>
+					<?php printf( __( 'Previous (%s)', 'pressbooks-book' ), $prev_label ); ?>
 				</a>
 			<?php } ?>
 		</div>
 		<div class="nav-reading__next js-nav-next">
 			<?php if ( $next_chapter !== '/' ) : ?>
 				<?php /* translators: %1$s: post title, %2$s: post type name */ ?>
-				<a href="<?php echo $next_chapter ?>" title="<?php printf( __( 'Next: %1$s (%2$s)', 'pressbooks-book' ), get_the_title( $next_chapter_id ), $next_chapter_post_type ); ?>">
+				<a href="<?php echo $next_chapter ?>" title="<?php printf( __( 'Next: %1$s (%2$s)', 'pressbooks-book' ), get_the_title( $next_chapter_id ), $next_label ); ?>">
 					<?php /* translators: %s: post type name */ ?>
-					<?php printf( __( 'Next (%s)', 'pressbooks-book' ), $next_chapter_post_type ); ?>
+					<?php printf( __( 'Next (%s)', 'pressbooks-book' ), $next_label ); ?>
 					<svg class="icon--svg"><use xlink:href="#arrow-right" /></svg>
 				</a>
 			<?php endif; ?>


### PR DESCRIPTION
Before:

![screen shot 2018-08-23 at 2 49 05 pm](https://user-images.githubusercontent.com/605361/44542610-b9375b80-a6e3-11e8-8994-d5c241b01fa3.png)

After:

![screen shot 2018-08-23 at 2 48 38 pm](https://user-images.githubusercontent.com/605361/44542624-c2282d00-a6e3-11e8-8211-6618e49d962a.png)

(For front matter/back matter with the 'Miscellaneous' type assigned, they will be labelled 'Front Matter' or 'Back Matter'.)