### PR TITLE
Support deleted source books in cloned book info (fix #254)

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -251,15 +251,17 @@ function display_menu() {
  */
 function get_source_book( $book_url, $checked = [] ) {
 	$output = $book_url;
-	$args   = [];
+	$args = [];
 	if ( defined( 'WP_ENV' ) && WP_ENV === 'development' ) {
 		$args['sslverify'] = false;
 	}
 	$response = wp_remote_get( untrailingslashit( $book_url ) . '/wp-json/pressbooks/v2/metadata/', $args );
-	$result   = json_decode( $response['body'], true );
-	if ( isset( $result['isBasedOn'] ) && ! in_array( $result['isBasedOn'], $checked, true ) ) {
-		$checked[] = $result['isBasedOn'];
-		$output    = get_source_book( $result['isBasedOn'], $checked );
+	if ( ! is_wp_error( $response ) ) {
+		$result = json_decode( $response['body'], true );
+		if ( isset( $result['isBasedOn'] ) && ! in_array( $result['isBasedOn'], $checked, true ) ) {
+			$checked[] = $result['isBasedOn'];
+			$output    = get_source_book( $result['isBasedOn'], $checked );
+		}
 	}
 	return $output;
 }
@@ -294,7 +296,12 @@ function get_source_book_url( $book_url ) {
 function get_source_book_meta( $source_url ) {
 	$source_meta = get_transient( 'pb_book_source_metadata' );
 	if ( $source_meta === false ) {
-		$source_meta = json_decode( wp_remote_get( untrailingslashit( $source_url ) . '/wp-json/pressbooks/v2/metadata/' )['body'], true );
+		$response = wp_remote_get( untrailingslashit( $source_url ) . '/wp-json/pressbooks/v2/metadata/' );
+		if ( ! is_wp_error( $response ) ) {
+			$source_meta = json_decode( $response['body'], true );
+		} else {
+			$source_meta = false;
+		}
 		set_transient( 'pb_book_source_metadata', $source_meta );
 	}
 	return $source_meta;

--- a/partials/content-cover-book-info.php
+++ b/partials/content-cover-book-info.php
@@ -23,14 +23,22 @@ if ( isset( $book_information['pb_is_based_on'] ) ) {
 		<h3 class="block__subtitle"><?php _e( 'Book Source', 'pressbooks-book' ); ?></h3>
 		<p>
 			<?php
-			printf(
-				/* translators: %$1s: title of book, linked to book, %2$s: author of book, %3$s: publisher of book, %4$s: license for book */
-				__( 'This book is a cloned version of %1$s by %2$s, published using Pressbooks by %3$s under a %4$s license. It may differ from the original.', 'pressbooks-book' ),
-				sprintf( '<a href="%1$s">%2$s</a>', $source_url, $source_meta['name'] ),
-				\Pressbooks\Book\Helpers\get_book_authors( $source_meta ),
-				( isset( $source_meta['publisher'] ) ) ? $source_meta['publisher']['name'] : '',
-				sprintf( '<a href="%1$s">%2$s</a>', $source_meta['license']['url'], $source_meta['license']['name'] )
-			);
+			if ( $source_meta ) {
+				printf(
+					/* translators: %$1s: title of book, link to book, %2$s: author of book, %3$s: publisher of book, %4$s: license for book */
+					__( 'This book is a cloned version of %1$s by %2$s, published using Pressbooks by %3$s under a %4$s license. It may differ from the original.', 'pressbooks-book' ),
+					sprintf( '<a href="%1$s">%2$s</a>', $source_url, $source_meta['name'] ),
+					\Pressbooks\Book\Helpers\get_book_authors( $source_meta ),
+					( isset( $source_meta['publisher'] ) ) ? $source_meta['publisher']['name'] : '',
+					sprintf( '<a href="%1$s">%2$s</a>', $source_meta['license']['url'], $source_meta['license']['name'] )
+				);
+			} else {
+				printf(
+					/* translators: %s: link to source book */
+					__( 'This book was cloned from a source that is no longer available. The source URL was %s. This book may differ from the original.', 'pressbooks-book' ),
+					sprintf( '<a href="%1$s">%1$s</a>', $source_url )
+				);
+			}
 			?>
 		</p>
 	</div>

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -6,7 +6,10 @@
  */
 
 use function \Pressbooks\Book\Helpers\get_metakeys;
- use function \Pressbooks\Book\Helpers\get_name_for_filetype;
+use function \Pressbooks\Book\Helpers\get_name_for_filetype;
+use function \Pressbooks\Book\Helpers\get_source_book;
+use function \Pressbooks\Book\Helpers\get_source_book_url;
+use function \Pressbooks\Book\Helpers\get_source_book_meta;
 use function \Pressbooks\Book\Helpers\license_to_icons;
 use function \Pressbooks\Book\Helpers\license_to_text;
 use function \Pressbooks\Book\Helpers\share_icons;
@@ -42,5 +45,18 @@ class HelpersTest extends WP_UnitTestCase {
 	}
 	function test_share_icons() {
 		$this->assertStringStartsWith( '<a class="sharer" data-sharer="twitter" data-title="Check out this great book on Pressbooks."', share_icons() );
+	}
+	function test_get_source_book() {
+		$output = get_source_book( 'https://book.pressbooks.com' );
+		$this->assertEquals( 'https://book.pressbooks.com', $output );
+	}
+	function test_get_source_book_url() {
+		$output = get_source_book_url( 'https://book.pressbooks.com' );
+		$this->assertEquals( 'https://book.pressbooks.com', $output );
+	}
+	function test_get_source_book_meta() {
+		$output = get_source_book_meta( 'https://book.pressbooks.com' );
+		$this->assertArrayHasKey( 'name', $output );
+		$this->assertEquals( "Book: A Futurist's Manifesto", $output['name'] );
 	}
 }


### PR DESCRIPTION
This is displayed if a source book has been deleted:

![screen shot 2018-08-27 at 2 55 20 pm](https://user-images.githubusercontent.com/605361/44676396-7fc75e80-aa09-11e8-9548-6f56fc66866e.png)
