### PR TITLE
pressbooks/pressbooks#1341: displaying credit override on book title page

### DIFF
--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -13,7 +13,9 @@ use function \Pressbooks\Image\attachment_id_from_url;
 		<?php if ( ! empty( $book_information['pb_subtitle'] ) ) : ?>
 			<p class="book-header__subtitle"><span class="screen-reader-text"><?php _e( 'Subtitle', 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_subtitle']; ?></p>
 		<?php endif; ?>
-		<?php if ( ! empty( $book_information['pb_authors'] ) ) { ?>
+		<?php if ( ! empty( $book_information['pb_credit_override'] ) ) { ?>
+			<p class="book-header__author"><span class="screen-reader-text"><?php echo _e( 'Attribution', 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_credit_override']; ?></p>
+		<?php } elseif ( ! empty( $book_information['pb_authors'] ) ) { ?>
 			<p class="book-header__author"><span class="screen-reader-text"><?php echo translate_nooped_plural( _n_noop( 'Author', 'Authors', 'pressbooks-book' ), \Pressbooks\Book\Helpers\count_authors( $book_information['pb_authors'] ), 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_authors']; ?></p>
 		<?php } ?>
 		<div class="book-header__cover">


### PR DESCRIPTION
Partially resolves pressbooks/pressbooks#1341.