### PR TITLE
Add RSS link to <head>

### DIFF
--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -173,6 +173,7 @@ function add_metadata() {
  */
 function theme_setup() {
 	load_theme_textdomain( 'pressbooks-book', get_template_directory() . '/languages' );
+	add_theme_support( 'automatic-feed-links' );
 	add_theme_support( 'title-tag' );
 	remove_action( 'wp_head', 'wp_generator' );
 }


### PR DESCRIPTION
As suggested by @baldurbjarnason, this PR outputs the default RSS feed in the webbook `<head>`.

```html
<link rel="alternate" type="application/rss+xml" title="Moby Dick » Feed" href="https://pressbooks.test/mobydick/feed/">
```