### PR TITLE
Fix paragraph styling on table cell paragraphs

### DIFF
--- a/packages/buckram/assets/styles/components/elements/_tables.scss
+++ b/packages/buckram/assets/styles/components/elements/_tables.scss
@@ -32,6 +32,9 @@
 
     p {
       text-align: $table-align;
+      @if $type == 'prince' {
+        line-height: $table-line-height;
+      }
     }
 
     caption {

--- a/packages/buckram/assets/styles/components/elements/_tables.scss
+++ b/packages/buckram/assets/styles/components/elements/_tables.scss
@@ -43,7 +43,7 @@
     }
     &.lines {
       border-color: if-map-get($line-color-1, $type);
-    } 
+    }
 
     &.lines tr {
       border-top: $table-border-width solid;
@@ -93,12 +93,12 @@
       float: left;
       margin-right: if-map-get($table-alignleft-margin-right, $type);
     }
-  
+
     &.aligncenter {
       margin-left: auto;
       margin-right: auto;
     }
-  
+
     &.alignright {
       float: right;
       margin-left: if-map-get($table-alignright-margin-left, $type);
@@ -164,6 +164,8 @@
 
       p {
         text-align: $table-align;
+        font-size: 1em;
+        line-height: $table-line-height;
       }
 
       caption {
@@ -187,7 +189,7 @@
       &.lines th {
         border-color: if-map-get($line-color-1, $type);
       }
-  
+
       &.lines td {
         border-color: if-map-get($line-color-1, $type);
       }
@@ -224,12 +226,12 @@
         float: left;
         margin-right: if-map-get($table-alignleft-margin-right, $type);
       }
-    
+
       &.aligncenter {
         margin-left: auto;
         margin-right: auto;
       }
-    
+
       &.alignright {
         float: right;
         margin-left: if-map-get($table-alignright-margin-left, $type);


### PR DESCRIPTION
The 'font-size: 1em;' may look weird, but it makes the table p the correct font size. 

fixes #242 