### PR TITLE
Numberless chapter targets before content

### DIFF
--- a/packages/buckram/assets/styles/components/section-titles/_chapters.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_chapters.scss
@@ -74,6 +74,9 @@
         &::after {
           content: '';
         }
+        &::before {
+          content: '';
+        }
       }
     }
 


### PR DESCRIPTION
This pull request makes sure the chapter number before content does not display if the chapter is set to numberless.