### PR TITLE
Remove unexpected blank page before copyright page (EPUB)

### DIFF
--- a/packages/buckram/assets/styles/components/pages/_front-matter.scss
+++ b/packages/buckram/assets/styles/components/pages/_front-matter.scss
@@ -14,7 +14,6 @@
 // Copyright Page
 
 #copyright-page {
-  page-break-before: always;
   margin-top: if-map-get($copyright-margin-top, $type);
   margin-right: if-map-get($copyright-margin-right, $type);
   margin-left: if-map-get($copyright-margin-left, $type);


### PR DESCRIPTION
This fixes an issue with a bunch of Buckram themes. We already allow the `page-break-before` property to respond to the recto-verso settings for PDF. This rule was adding a blank page before the copyright page in EPUB exports, which it should not.