### PR TITLE
Chapter licenses fix

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -644,12 +644,10 @@ function copyright_license( $show_custom_copyright = true ) {
  */
 function do_license( $metadata ) {
 	global $post;
-	$id    = $post->ID;
-	$title = ( is_front_page() ) ? get_bloginfo( 'name' ) : $post->post_title;
-
+	$id = $post->ID;
 	try {
 		$licensing = new \Pressbooks\Licensing();
-		return $licensing->doLicense( $metadata, $id, $title );
+		return $licensing->doLicense( $metadata, $id );
 	} catch ( \Exception $e ) {
 		error_log( $e->getMessage() ); // @codingStandardsIgnoreLine
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,8 +18,12 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
-	$_pressbooks_dir = '/tmp/wordpress/wp-content/plugins/pressbooks';
-	require_once( $_pressbooks_dir . '/pressbooks.php' );
+	$_pressbooks = '/tmp/wordpress/wp-content/plugins/pressbooks/pressbooks.php';
+	if ( file_exists( $_pressbooks ) ) {
+		require_once( $_pressbooks );
+	} else {
+		require_once( __DIR__ . '/../../../plugins/pressbooks/pressbooks.php' );
+	}
 }
 
 function _register_theme() {

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -25,6 +25,18 @@ use function \Pressbooks\Book\Helpers\social_media_enabled;
  */
 class HelpersTest extends WP_UnitTestCase {
 
+	private function _setupGlobalPost() {
+		$new_post = [
+			'post_title' => 'Test Chapter',
+			'post_type' => 'chapter',
+			'post_status' => 'publish',
+			'post_content' => 'My test chapter.',
+		];
+		$post_id = $this->factory()->post->create_object( $new_post );
+		global $post;
+		$post = get_post( $post_id );
+	}
+
 	function test_get_name_for_filetype() {
 		$output = get_name_for_filetype( 'pdf' );
 		$this->assertEquals( 'Digital PDF', $output );
@@ -156,5 +168,11 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 1, $result );
 		$result = count_authors( '' );
 		$this->assertEquals( 0, $result );
+	}
+
+	function test_do_license() {
+		$this->_setupGlobalPost();
+		$license = \Pressbooks\Book\Helpers\do_license( [] );
+		$this->assertContains( '<div class="license-attribution">', $license );
 	}
 }


### PR DESCRIPTION
Unless chapter is licensed differently, it should display the book license statement

Depends on https://github.com/pressbooks/pressbooks/pull/1561