### PR TITLE
Fall back to shaded variable for textbox colours

### DIFF
--- a/packages/buckram/assets/styles/components/_colors.scss
+++ b/packages/buckram/assets/styles/components/_colors.scss
@@ -226,13 +226,13 @@ div.sidebar {
   background-color: if-map-get($sidebar-color, $type);
 }
 
-div.textbox {
+.textbox {
   background-color: if-map-get($textbox-background-color, $type);
   border-color: if-map-get($textbox-border-color, $type);
 }
 
 .textbox.shaded {
-  background-color: if-map-get($shaded-color, $type);
+  background-color: if-map-get($textbox-shaded-background-color, $type);
 }
 
 // SHADED COLOR

--- a/packages/buckram/assets/styles/components/specials/_textboxes.scss
+++ b/packages/buckram/assets/styles/components/specials/_textboxes.scss
@@ -139,10 +139,6 @@
     font-weight: $textbox-caption-font-weight;
   }
 
-  &.shaded {
-    background-color: if-map-get($textbox-shaded-background-color, $type);
-  }
-
   &.learning-objectives {
     @include educational-textbox($learning-objectives-header-color, $learning-objectives-header-background, $learning-objectives-color, $learning-objectives-background);
   }

--- a/packages/buckram/assets/styles/variables/_colors.scss
+++ b/packages/buckram/assets/styles/variables/_colors.scss
@@ -106,7 +106,7 @@ $textbox-background-color: initial !default;
 $shaded-color: $color-4 !default;
 /// Textbox shaded Background color on elements with a class of `textbox` and a class of `shaded`.
 /// @type String
-$textbox-shaded-background-color: $shaded !default;
+$textbox-shaded-background-color: $shaded-color !default;
 /// Textbox border color for `<div>` elements with class `.sidebar`.
 /// @type String
 $textbox-border-color: $color-1 !default;

--- a/packages/buckram/assets/styles/variables/_colors.scss
+++ b/packages/buckram/assets/styles/variables/_colors.scss
@@ -101,12 +101,15 @@ $sidebar-color: $color-4 !default;
 /// Textbox color for `<div>` elements with class `.textbox`.
 /// @type String
 $textbox-background-color: initial !default;
-/// Textbox border color for `<div>` elements with class `.sidebar`.
-/// @type String
-$textbox-border-color: $color-1 !default;
 /// Shading color for `<div>` elements with class `.sidebar.shaded`.
 /// @type String
 $shaded-color: $color-4 !default;
+/// Textbox shaded Background color on elements with a class of `textbox` and a class of `shaded`.
+/// @type String
+$textbox-shaded-background-color: $shaded !default;
+/// Textbox border color for `<div>` elements with class `.sidebar`.
+/// @type String
+$textbox-border-color: $color-1 !default;
 /// Top border color on break symbols on elements with a class of `break-symbols` that are children of `<hr>` elements.
 /// @type String | Map
 /// @since 1.2.0

--- a/packages/buckram/assets/styles/variables/_specials.scss
+++ b/packages/buckram/assets/styles/variables/_specials.scss
@@ -599,7 +599,7 @@ $textbox-background-color: initial !default;
 
 /// Textbox shaded Background color on elements with a class of `textbox` and a class of `shaded`.
 /// @type String
-$textbox-shaded-background-color: #eee !default;
+$textbox-shaded-background-color: $shaded-color !default;
 
 /// Textbox top padding on elements with a class of `textbox`.
 /// @type String | Map


### PR DESCRIPTION
At some point we somehow ended up with two separate colour variables both of which are supposed to do the same thing— provide the background colour for shaded textboxes. This PR unifies them.