### PR TITLE
Center interactivate content fallback images

### DIFF
--- a/packages/buckram/assets/styles/components/media/_interactive-content.scss
+++ b/packages/buckram/assets/styles/components/media/_interactive-content.scss
@@ -30,6 +30,8 @@
   img {
     display: block;
     margin-bottom: if-map-get($interactive-thumbnail-margin-bottom, $type);
+    margin-left: auto;
+    margin-right: auto;
   }
 
   p {


### PR DESCRIPTION
This PR ensures that interactive content fallback images are always centred, regardless of page size.