### PR TITLE
Add $section-author-text-indent variable

### DIFF
--- a/packages/buckram/CHANGELOG.md
+++ b/packages/buckram/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+
+- Add `$section-author-text-indent` variable: [#501](https://github.com/pressbooks/pressbooks-book/pull/501)
+
 ## 1.3.3
 
 ### Patches

--- a/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
@@ -70,6 +70,7 @@
       font-weight: $section-author-font-weight;
       hyphens: none;
       text-align: $section-author-align;
+      text-indent: if-map-get($section-author-text-indent, $type);
       text-transform: $section-author-text-transform;
       letter-spacing: if-map-get($section-author-letter-spacing, $type);
       word-spacing: if-map-get($section-author-word-spacing, $type);

--- a/packages/buckram/assets/styles/components/section-titles/_chapters.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_chapters.scss
@@ -106,6 +106,7 @@
       font-weight: $section-author-font-weight;
       hyphens: none;
       text-align: $section-author-align;
+      text-indent: if-map-get($section-author-text-indent, $type);
       text-transform: $section-author-text-transform;
       letter-spacing: if-map-get($section-author-letter-spacing, $type);
       word-spacing: if-map-get($section-author-word-spacing, $type);

--- a/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
@@ -70,6 +70,7 @@
       font-weight: $section-author-font-weight;
       hyphens: none;
       text-align: $section-author-align;
+      text-indent: if-map-get($section-author-text-indent, $type);
       text-transform: $section-author-text-transform;
       letter-spacing: if-map-get($section-author-letter-spacing, $type);
       word-spacing: if-map-get($section-author-word-spacing, $type);

--- a/packages/buckram/assets/styles/components/section-titles/_generic.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_generic.scss
@@ -82,6 +82,7 @@
         font-weight: $section-author-font-weight;
         hyphens: none;
         text-align: $section-author-align;
+        text-indent: if-map-get($section-author-text-indent, $type);
         text-transform: $section-author-text-transform;
         letter-spacing: if-map-get($section-author-letter-spacing, $type);
         word-spacing: if-map-get($section-author-word-spacing, $type);

--- a/packages/buckram/assets/styles/variables/_section-titles.scss
+++ b/packages/buckram/assets/styles/variables/_section-titles.scss
@@ -302,6 +302,11 @@ $section-author-font-weight: normal !default;
 /// @type String
 $section-author-align: center !default;
 
+/// Defines the section author text indent.
+/// @since 1.4.0
+/// @type String | Map
+$section-author-text-indent: 0 !default;
+
 /// Defines the section author text transform.
 /// @type String
 $section-author-text-transform: uppercase !default;
@@ -1010,7 +1015,7 @@ $chapter-number-margin-left: (
 /// Defines the chapter number bottom padding.
 /// @type String | Map
 /// @since 1.0.0
-$chapter-number-padding-bottom:$section-title-padding-bottom !default;
+$chapter-number-padding-bottom: $section-title-padding-bottom !default;
 
 /// Defines the bottom border width for the chapter number.
 /// @type String | Map


### PR DESCRIPTION
This prevents text-indent rules applied to paragraphs from indenting section authors.