### PR TITLE
Add 'if-map-get' to dt-color variable to fix parse error (fix: #527)

### DIFF
--- a/packages/buckram/assets/styles/components/elements/_lists.scss
+++ b/packages/buckram/assets/styles/components/elements/_lists.scss
@@ -286,7 +286,7 @@
     if-map-get($dt-margin-left, $type);
   font-style: $dt-font-style;
   font-weight: $dt-font-weight;
-  color: $dt-color;
+  color: if-map-get($dt-color, $type);
 }
 
 %dfn {


### PR DESCRIPTION
fixes #527 