### PR TITLE
Change footnote font size in prince from `em` to `rem`

### DIFF
--- a/packages/buckram/CHANGELOG.md
+++ b/packages/buckram/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Remove running content from blank pages on post introduction front matter: [#522](https://github.com/pressbooks/pressbooks-book/pull/522)
 - Add 'if-map-get' to dt-color variable to fix parse error: [#528](https://github.com/pressbooks/pressbooks-book/pull/528)
 - Fix: MOBI Table of Contents cannot be clicked: [#543](https://github.com/pressbooks/pressbooks-book/pull/543)
-- Fix: Footnotes in headers inherit header styles: [#544](https://github.com/pressbooks/pressbooks-book/pull/544)
+- Fix: Footnotes in headers inherit header styles: [#544](https://github.com/pressbooks/pressbooks-book/pull/544) [#546](https://github.com/pressbooks/pressbooks-book/pull/546)
 
 ## 1.3.3
 

--- a/packages/buckram/assets/styles/variables/_specials.scss
+++ b/packages/buckram/assets/styles/variables/_specials.scss
@@ -103,7 +103,7 @@ $footnote-font-family: $body-font-family !default;
 /// @type String | Map
 $footnote-font-size: (
   epub: 0.9em,
-  prince: 0.8em,
+  prince: 0.8rem,
   web: 0.9em
 ) !default;
 


### PR DESCRIPTION
An update to this PR: https://github.com/pressbooks/pressbooks-book/pull/544