### PR TITLE
Add extra footnote variables to prevent inheriting parent styles

### DIFF
--- a/packages/buckram/CHANGELOG.md
+++ b/packages/buckram/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Remove running content from blank pages on post introduction front matter: [#522](https://github.com/pressbooks/pressbooks-book/pull/522)
 - Add 'if-map-get' to dt-color variable to fix parse error: [#528](https://github.com/pressbooks/pressbooks-book/pull/528)
 - Fix: MOBI Table of Contents cannot be clicked: [#543](https://github.com/pressbooks/pressbooks-book/pull/543)
-- Fix: Footnotes in headers inherit header styles: [#544](https://github.com/pressbooks/pressbooks-book/pull/544) [#546](https://github.com/pressbooks/pressbooks-book/pull/546)
+- Fix: Footnotes in headers inherit header styles: [#544](https://github.com/pressbooks/pressbooks-book/pull/544) [#546](https://github.com/pressbooks/pressbooks-book/pull/546) [#547](https://github.com/pressbooks/pressbooks-book/pull/547)
 
 ## 1.3.3
 

--- a/packages/buckram/assets/styles/components/specials/_footnotes.scss
+++ b/packages/buckram/assets/styles/components/specials/_footnotes.scss
@@ -30,9 +30,13 @@
     font-family: if-map-get($footnote-font-family, $type);
     font-size: if-map-get($footnote-font-size, $type);
     font-weight: if-map-get($footnote-font-weight, $type);
+    letter-spacing: if-map-get($footnote-letter-spacing, $type);
+    word-spacing: if-map-get($footnote-word-spacing, $type);
+    color: if-map-get($footnote-color, $type);
     line-height: $footnote-line-height;
     text-align: if-map-get($footnote-align, $type);
     text-indent: $footnote-indent;
+    text-transform: if-map-get($footnote-text-transform, $type);
     counter-increment: footnote;
     footnote-style-position: outside;
   }

--- a/packages/buckram/assets/styles/variables/_colors.scss
+++ b/packages/buckram/assets/styles/variables/_colors.scss
@@ -118,6 +118,10 @@ $hr-break-symbols-border-top-color: $color-3 !default;
 /// @type String
 /// @since 1.4.0
 $dt-color: $color-3 !default;
+/// Color for footnotes on elements with class of`.footnote`.
+/// @type String
+/// @since 1.4.0
+$footnote-color: $color-1 !default;
 
 //TITLE PAGE(S) COLOR
 

--- a/packages/buckram/assets/styles/variables/_specials.scss
+++ b/packages/buckram/assets/styles/variables/_specials.scss
@@ -129,6 +129,21 @@ $footnote-indent: 0 !default;
 /// @since 1.2.0
 $footnote-align: (epub: left, prince: left, web: left) !default;
 
+/// Text transform for footnote for elements with a class of `footnote`.
+/// @type String | Map
+/// @since 1.4.0
+$footnote-text-transform: (epub: none, prince: none, web: none) !default;
+
+/// Letter spacing for footnote for elements with a class of `footnote`.
+/// @type String | Map
+/// @since 1.4.0
+$footnote-letter-spacing: (epub: normal, prince: normal, web: normal) !default;
+
+/// Word spacing for footnote for elements with a class of `footnote`.
+/// @type String | Map
+/// @since 1.4.0
+$footnote-word-spacing: (epub: normal, prince: normal, web: normal) !default;
+
 /// Top Margin for footnote blockquote for elements with a class of `fn-blockquote`.
 /// @type String
 $footnote-blockquote-margin-top: 0.5em !default;


### PR DESCRIPTION
Related: https://github.com/pressbooks/pressbooks-book/pull/546 https://github.com/pressbooks/pressbooks-book/pull/544