### PR TITLE
Target toc-part-title-color variable for print

### DIFF
--- a/packages/buckram/CHANGELOG.md
+++ b/packages/buckram/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - TODO
 
+### Patches
+- Fix color variable for Table of Contents part title: [#559](https://github.com/pressbooks/pressbooks-book/pull/559)
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/buckram/assets/styles/components/toc/_generic.scss
+++ b/packages/buckram/assets/styles/components/toc/_generic.scss
@@ -330,7 +330,7 @@
       color: if-map-get($toc-front-matter-author-color, $type);
     }
 
-    .part {
+    .part a {
       color: if-map-get($toc-part-title-color, $type);
     }
 


### PR DESCRIPTION
fix #558

Add missing 'a' to make sure color is targeting the TOC part title.