### PR TITLE
Change default pullquote styling to 'inline-block' for PDF exports

### DIFF
--- a/packages/buckram/assets/styles/components/specials/_pullquotes.scss
+++ b/packages/buckram/assets/styles/components/specials/_pullquotes.scss
@@ -25,7 +25,7 @@ aside,
 // Pullquotes
 
 %pullquote {
-  display: block;
+  display: inline-block;
   font-family: $pullquote-font-family;
   font-size: $pullquote-font-size;
   font-style: $pullquote-font-style;


### PR DESCRIPTION
Fixes https://github.com/pressbooks/pressbooks-book/issues/337