### PR TITLE
Remove extra SCSS

### DIFF
--- a/packages/buckram/assets/styles/components/specials/_footnotes.scss
+++ b/packages/buckram/assets/styles/components/specials/_footnotes.scss
@@ -145,9 +145,3 @@
     text-indent: 0;
   }
 }
-
-#content {
-  .footnotes, .before-footnotes, .media-attributions {
-    clear: both;
-  }
-}


### PR DESCRIPTION
Removes extra SCSS rules (.clear already exists and can be used to achieve desired effect).