### PR TITLE
Add support for Armenian language scripts, fix textbox heading color & clone attribution bugs

### DIFF
--- a/assets/book/typography/styles/_NotoSansArmenianFont.scss
+++ b/assets/book/typography/styles/_NotoSansArmenianFont.scss
@@ -1,0 +1,15 @@
+// 'Noto Sans Armenian', @import 'NotoSansArmenianFont'
+
+@font-face {
+  font-family: 'Noto Sans Armenian';
+  font-style: normal;
+  font-weight: 400;
+  src: url('uploads/assets/fonts/NotoSansArmenian-Regular.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'Noto Sans Armenian';
+  font-style: bold;
+  font-weight: 700;
+  src: url('uploads/assets/fonts/NotoSansArmenian-Bold.ttf') format('truetype');
+}

--- a/assets/book/typography/styles/_NotoSansDevanagariFont.scss
+++ b/assets/book/typography/styles/_NotoSansDevanagariFont.scss
@@ -9,7 +9,7 @@
 
 @font-face {
   font-family: 'Noto Sans Devanagari';
-  font-style: normal;
+  font-style: bold;
   font-weight: 700;
   src: url('uploads/assets/fonts/NotoSansDevanagari-Bold.ttf') format('truetype');
 }

--- a/assets/book/typography/styles/_NotoSerifArmenianFont.scss
+++ b/assets/book/typography/styles/_NotoSerifArmenianFont.scss
@@ -1,0 +1,15 @@
+// 'Noto Serif Armenian', @import 'NotoSerifArmenianFont'
+
+@font-face {
+  font-family: 'Noto Serif Armenian';
+  font-style: normal;
+  font-weight: 400;
+  src: url('uploads/assets/fonts/NotoSerifArmenian-Regular.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'Noto Serif Armenian';
+  font-style: bold;
+  font-weight: 700;
+  src: url('uploads/assets/fonts/NotoSerifArmenian-Bold.ttf') format('truetype');
+}

--- a/assets/book/typography/styles/_fonts-hy.scss
+++ b/assets/book/typography/styles/_fonts-hy.scss
@@ -1,0 +1,13 @@
+@import 'NotoSansArmenianFont', 'NotoSerifArmenianFont';
+
+// Sans-serif stack name
+
+$sans-serif-epub-hy: 'Noto Sans Armenian';
+$sans-serif-prince-hy: 'Noto Sans Armenian';
+$sans-serif-web-hy: 'Noto Sans Armenian';
+
+// Serif stack-name
+
+$serif-epub-hy: 'Noto Serif Armenian';
+$serif-prince-hy: 'Noto Serif Armenian';
+$serif-web-hy: 'Noto Serif Armenian';

--- a/packages/buckram/assets/styles/components/specials/_textboxes.scss
+++ b/packages/buckram/assets/styles/components/specials/_textboxes.scss
@@ -72,6 +72,10 @@
       if-map-get($edu-textbox-padding-left, $type);
     text-align: $edu-header-text-align;
 
+    h1, h2, h3, h4, h5, h6 {
+      color: $header-color;
+    }
+
     p {
       text-indent: 0;
     }

--- a/partials/content-cover-book-info.php
+++ b/partials/content-cover-book-info.php
@@ -31,6 +31,7 @@ if ( isset( $book_information['pb_is_based_on'] ) ) {
 					sprintf( '<a href="%1$s">%2$s</a>', $source_url, $source_meta['name'] ),
 					/* translators: %2$s: authors of book */
 					( $authors ) ? sprintf( __( ' by %s', 'pressbooks-book' ), $authors ) : '',
+					/* translators: %3$s: publisher of book */
 					( isset( $source_meta['publisher'] ) ) ? sprintf( __( ' by %s', 'pressbooks-book' ), $source_meta['publisher']['name'] ) : '',
 					sprintf( '<a href="%1$s">%2$s</a>', $source_meta['license']['url'], $source_meta['license']['name'] )
 				);

--- a/partials/content-cover-book-info.php
+++ b/partials/content-cover-book-info.php
@@ -27,11 +27,11 @@ if ( isset( $book_information['pb_is_based_on'] ) ) {
 				$authors = \PressbooksBook\Helpers\get_book_authors( $source_meta );
 				printf(
 					/* translators: %$1s: title of book, link to book, %2$s: attribution string for the book, %3$s: publisher of book, %4$s: license for book */
-					__( 'This book is a cloned version of %1$s%2$s, published using Pressbooks by %3$s under a %4$s license. It may differ from the original.', 'pressbooks-book' ),
+					__( 'This book is a cloned version of %1$s%2$s, published using Pressbooks%3$s under a %4$s license. It may differ from the original.', 'pressbooks-book' ),
 					sprintf( '<a href="%1$s">%2$s</a>', $source_url, $source_meta['name'] ),
 					/* translators: %2$s: authors of book */
 					( $authors ) ? sprintf( __( ' by %s', 'pressbooks-book' ), $authors ) : '',
-					( isset( $source_meta['publisher'] ) ) ? $source_meta['publisher']['name'] : '',
+					( isset( $source_meta['publisher'] ) ) ? sprintf( __( ' by %s', 'pressbooks-book' ), $source_meta['publisher']['name'] ) : '',
 					sprintf( '<a href="%1$s">%2$s</a>', $source_meta['license']['url'], $source_meta['license']['name'] )
 				);
 			} else {


### PR DESCRIPTION
Add support for Armenian language scripts. Along with https://github.com/pressbooks/pressbooks/pull/1946, provides fix for https://github.com/pressbooks/ideas/issues/313

Fix for https://github.com/pressbooks/pressbooks-book/issues/695 by ensuring that heading elements inside of textbox__header elements receive expected color value.

Fix for https://github.com/pressbooks/pressbooks-book/issues/694 by moving extra 'by' statement before publisher name inside of conditional check for book clone attribution.