### PR TITLE
Fix positioning for images without caption in PDFs

### DIFF
--- a/.github/workflows/.pipeline.yml
+++ b/.github/workflows/.pipeline.yml
@@ -31,7 +31,9 @@ jobs:
           node-version: '10'
 
       - name: Install OS dependencies
-        run: sudo apt-get install libxml2-utils ghostscript poppler-utils
+        run: |
+          sudo apt update
+          sudo apt-get install libxml2-utils ghostscript poppler-utils
 
       - name: Start required services
         run: sudo systemctl start mysql.service

--- a/packages/buckram/assets/styles/components/media/_images.scss
+++ b/packages/buckram/assets/styles/components/media/_images.scss
@@ -254,7 +254,6 @@ p {
         clear: both;
     }
   }
-
 }
 
 @else if $type == 'web' {

--- a/packages/buckram/assets/styles/components/media/_images.scss
+++ b/packages/buckram/assets/styles/components/media/_images.scss
@@ -9,6 +9,40 @@
   }
 }
 
+p {
+  img {
+    &.aligncenter {
+      margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
+      text-align: center;
+      display: block;
+
+      @include caption-text-align(center);
+    }
+
+    &.alignleft {
+      float: left;
+      margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
+      padding-right: 0;
+
+      @include caption-text-align(left);
+    }
+
+    &.alignright {
+      float: right;
+      margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
+      padding-left: 0;
+
+      @include caption-text-align(right);
+    }
+
+    @if $type != 'web' {
+      &.aligncenter, &.alignleft, &.alignright {
+        max-width: 50%;
+      }
+    }
+  }
+}
+
 @if $type == 'epub' {
   figcaption,
   .wp-caption-text {
@@ -118,36 +152,6 @@
       clear: both;
     }
   }
-
-  p {
-    img {
-      &.aligncenter {
-        margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
-        text-align: center;
-        max-width: 50%;
-
-        @include caption-text-align(center);
-      }
-
-      &.alignleft {
-        float: left;
-        margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
-        max-width: 50%;
-        padding-right: 0;
-
-        @include caption-text-align(left);
-      }
-
-      &.alignright {
-        float: right;
-        margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
-        max-width: 50%;
-        padding-left: 0;
-
-        @include caption-text-align(right);
-      }
-    }
-  }
 }
 
 @else if $type == 'prince' {
@@ -251,36 +255,6 @@
     }
   }
 
-  p {
-    img {
-      &.aligncenter {
-        margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
-        max-width: 50%;
-        text-align: center;
-        display: block;
-
-        @include caption-text-align(center);
-      }
-
-      &.alignleft {
-        float: left;
-        margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
-        max-width: 50%;
-        padding-right: 0;
-
-        @include caption-text-align(left);
-      }
-
-      &.alignright {
-        float: right;
-        margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
-        max-width: 50%;
-        padding-left: 0;
-
-        @include caption-text-align(right);
-      }
-    }
-  }
 }
 
 @else if $type == 'web' {
@@ -362,36 +336,6 @@
         padding-right: 0;
 
         @include caption-text-align(right);
-      }
-    }
-
-    p {
-      img {
-        &.aligncenter {
-          margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
-          text-align: center;
-          max-width: 100%;
-
-          @include caption-text-align(center);
-        }
-
-        &.alignleft {
-          float: left;
-          margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
-          max-width: 50%;
-          padding-right: 0;
-
-          @include caption-text-align(left);
-        }
-
-        &.alignright {
-          float: right;
-          margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
-          max-width: 50%;
-          padding-left: 0;
-
-          @include caption-text-align(right);
-        }
       }
     }
   }

--- a/packages/buckram/assets/styles/components/media/_images.scss
+++ b/packages/buckram/assets/styles/components/media/_images.scss
@@ -124,6 +124,7 @@
       &.aligncenter {
         margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
         text-align: center;
+        max-width: 50%;
 
         @include caption-text-align(center);
       }
@@ -254,7 +255,9 @@
     img {
       &.aligncenter {
         margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
+        max-width: 50%;
         text-align: center;
+        display: block;
 
         @include caption-text-align(center);
       }
@@ -367,6 +370,7 @@
         &.aligncenter {
           margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
           text-align: center;
+          max-width: 100%;
 
           @include caption-text-align(center);
         }

--- a/packages/buckram/assets/styles/components/media/_images.scss
+++ b/packages/buckram/assets/styles/components/media/_images.scss
@@ -118,6 +118,39 @@
       clear: both;
     }
   }
+
+  p {
+    img {
+      &.aligncenter {
+        margin-left: auto;
+        margin-right: auto;
+        text-align: center;
+        width: auto;
+
+        @include caption-text-align(center);
+      }
+
+      &.alignleft {
+        float: left;
+        margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
+        max-width: 50%;
+        padding-right: 0;
+        width: 100%;
+
+        @include caption-text-align(left);
+      }
+
+      &.alignright {
+        float: right;
+        margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
+        max-width: 50%;
+        padding-left: 0;
+        width: 100%;
+
+        @include caption-text-align(right);
+      }
+    }
+  }
 }
 
 @else if $type == 'prince' {
@@ -220,6 +253,35 @@
         clear: both;
     }
   }
+
+  p {
+    img {
+      &.aligncenter {
+        margin-right: auto;
+        margin-left: auto;
+        text-align: center;
+
+        @include caption-text-align(center);
+      }
+
+      &.alignleft {
+        float: left;
+        margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
+        max-width: 50%;
+
+        @include caption-text-align(left);
+      }
+
+      &.alignright {
+        float: right;
+        margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
+        max-width: 50%;
+        padding-right: 0;
+
+        @include caption-text-align(right);
+      }
+    }
+  }
 }
 
 @else if $type == 'web' {
@@ -301,6 +363,34 @@
         padding-right: 0;
 
         @include caption-text-align(right);
+      }
+    }
+
+    p {
+      img {
+        &.aligncenter {
+          margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
+          text-align: center;
+
+          @include caption-text-align(center);
+        }
+
+        &.alignleft {
+          float: left;
+          margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
+          max-width: 50%;
+
+          @include caption-text-align(left);
+        }
+
+        &.alignright {
+          float: right;
+          margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
+          max-width: 50%;
+          padding-right: 0;
+
+          @include caption-text-align(right);
+        }
       }
     }
   }

--- a/packages/buckram/assets/styles/components/media/_images.scss
+++ b/packages/buckram/assets/styles/components/media/_images.scss
@@ -122,10 +122,8 @@
   p {
     img {
       &.aligncenter {
-        margin-left: auto;
-        margin-right: auto;
+        margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
         text-align: center;
-        width: auto;
 
         @include caption-text-align(center);
       }
@@ -135,7 +133,6 @@
         margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
         max-width: 50%;
         padding-right: 0;
-        width: 100%;
 
         @include caption-text-align(left);
       }
@@ -145,7 +142,6 @@
         margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
         max-width: 50%;
         padding-left: 0;
-        width: 100%;
 
         @include caption-text-align(right);
       }
@@ -257,8 +253,7 @@
   p {
     img {
       &.aligncenter {
-        margin-right: auto;
-        margin-left: auto;
+        margin: if-map-get($image-wrapper-margin-top, $type) auto if-map-get($image-wrapper-margin-bottom, $type);
         text-align: center;
 
         @include caption-text-align(center);
@@ -268,6 +263,7 @@
         float: left;
         margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
         max-width: 50%;
+        padding-right: 0;
 
         @include caption-text-align(left);
       }
@@ -276,7 +272,7 @@
         float: right;
         margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
         max-width: 50%;
-        padding-right: 0;
+        padding-left: 0;
 
         @include caption-text-align(right);
       }
@@ -379,6 +375,7 @@
           float: left;
           margin: if-map-get($image-wrapper-margin-top, $type) if-map-get($image-alignleft-margin-right, $type) if-map-get($floated-image-wrapper-margin-bottom, $type) 0;
           max-width: 50%;
+          padding-right: 0;
 
           @include caption-text-align(left);
         }
@@ -387,7 +384,7 @@
           float: right;
           margin: if-map-get($image-wrapper-margin-top, $type) 0 if-map-get($floated-image-wrapper-margin-bottom, $type) if-map-get($image-alignright-margin-left, $type);
           max-width: 50%;
-          padding-right: 0;
+          padding-left: 0;
 
           @include caption-text-align(right);
         }


### PR DESCRIPTION
This should fix #791 and #792 

This PR attempts to solve PDF and EPUB floating image positioning.
It also fixes a GitHub pipeline issue that @ho-man-chan mentioned.

#### How to test
* Create a book with floating (left, right) and centered images with no caption
* Check that the book renders properly as web pages
* Export a PDF and/or EPUB version of the book and check if the content is properly rendered
* Make sure that inline images keep rendering as inline
