### PR TITLE
Fix HTML structure bug in content-single

### DIFF
--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -64,17 +64,18 @@
 	} else {
 		echo apply_filters( 'the_content', $post->post_content );
 	}
-	// TODO: add better check so that we only display the About the Authors section if we have authors && at least one of the authors has more than just a name & profile pic?
+	// TODO: add better check to display About the Authors section if at least one author has more than just a name & profile pic?
 	if ( $authors ) {
 		?>
 	<div class="contributors">
 		<h3 class="about-authors">About the Authors</h3>
 		<?php
-		{
 		foreach ( $full_authors as $contributor ) {
 			include( locate_template( 'partials/content-contributor-profile.php' ) );
 		}
-		}
+		?>
+	</div>
+	<?php
 	}
 	?>
 </section>

--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -1,4 +1,4 @@
-<section data-type="<?php echo $datatype; ?>" <?php post_class( pb_get_section_type( $post ) ); ?>>
+<section data-type="<?php echo $datatype; ?>" <?php post_class( pb_get_section_type( $post ) ); ?>
 	<header>
 		<h1 class="entry-title">
 			<?php
@@ -77,7 +77,6 @@
 		}
 	}
 	?>
-	</div>
 </section>
 <?php
 edit_post_link( __( 'Edit', 'pressbooks-book' ), '<div class="edit-link">', '</div>', $post->ID, 'call-to-action' );

--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -75,7 +75,7 @@
 		}
 		?>
 	</div>
-	<?php
+		<?php
 	}
 	?>
 </section>


### PR DESCRIPTION
Currently, the edit chapter button is placed outside of the content div when there are no authors assigned to a chapter:
![Screenshot from 2021-08-18 14-03-51](https://user-images.githubusercontent.com/13485451/129975902-479d7aba-22ba-467f-af2b-cfe06746dfaa.png)
This PR fixes this bug, which was accidentally introduced into the content-single page template during the hackathon. 

**To test:**
1. Apply this branch
2. Log into a book
3. Open a chapter that does not have an author assigned
4. View the placement of the edit chapter button at the bottom of the content block
5. Open a chapter that does have an author assigned in chapter metadata
6. View the placement of the edit chapter button at the bottom of the content block
Both cases should look like this:

![Screenshot from 2021-08-18 14-39-48](https://user-images.githubusercontent.com/13485451/129975872-0af15621-49be-4be6-9af7-e6bbf578f8a6.png)
