### PR TITLE
Display or hide about the authors section depending on global options

### DIFF
--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -64,8 +64,8 @@
 	} else {
 		echo apply_filters( 'the_content', $post->post_content );
 	}
-	// TODO: add better check to display About the Authors section if at least one author has more than just a name & profile pic?
-	if ( $authors ) {
+	if ( $display_about_the_author && $authors ) {
+		// TODO: add better check to display About the Authors section if at least one author has more than just a name & profile pic?
 		?>
 	<div class="contributors">
 		<h3 class="about-authors">About the Authors</h3>

--- a/single.php
+++ b/single.php
@@ -7,8 +7,10 @@
 			$number       = ( $post->post_type === 'chapter' ) ? pb_get_chapter_number( $post->ID ) : false;
 			$subtitle     = get_post_meta( $post->ID, 'pb_subtitle', true );
 			$contributors = new \Pressbooks\Contributors();
+			$display_about_the_author = ! empty( get_option( 'pressbooks_theme_options_global', [] )['about_the_author'] );
 			$authors      = $contributors->get( $post->ID, 'authors' );
-			$full_authors  = $contributors->getFullContributors( $post->ID, 'authors' );
+			$full_authors  = ! $display_about_the_author ?:
+					$contributors->getFullContributors( $post->ID, 'authors' );
 			$datatype     = ( in_array( $post->post_type, [ 'front-matter', 'back-matter' ], true ) ) ? pb_get_section_type( $post ) : $post->post_type;
 			if ( isset( $web_options['part_title'] ) && absint( $web_options['part_title'] ) === 1 ) {
 				if ( $post->post_type === 'chapter' ) {


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-book/issues/832

This PR is for hiding or displaying the **About the authors** bottom section for each chapter, depending on the `about_the_authors` boolean global option.

See:  for details about how to test it.