### PR TITLE
Adjust image size only for left and right aligned ones

### DIFF
--- a/packages/buckram/assets/styles/components/media/_images.scss
+++ b/packages/buckram/assets/styles/components/media/_images.scss
@@ -36,7 +36,7 @@ p {
     }
 
     @if $type != 'web' {
-      &.aligncenter, &.alignleft, &.alignright {
+      &.alignleft, &.alignright {
         max-width: 50%;
       }
     }


### PR DESCRIPTION
Issue #850 

This PR removes image adjustments on PDFs for centered aligned images ([see](https://github.com/pressbooks/pressbooks-book/issues/850#issuecomment-910356523)).

#### How to test

1. Import an image, and insert as "large" into a chapter.
1. Set an alignment for center, left or right.
1. Export as a PDF
1. Left and right aligned images should have the sized adjusted. Centered images should remain untouched.

![image](https://user-images.githubusercontent.com/1761690/131705825-3ee25812-247a-4e7f-876c-429c672b7922.png)


