### PR TITLE
Fix page number HTML

### DIFF
--- a/packages/buckram/assets/styles/components/toc/_generic.scss
+++ b/packages/buckram/assets/styles/components/toc/_generic.scss
@@ -219,10 +219,10 @@
 }
 
 @if $type == 'prince' {
-  h3.front-matter-number,
-  h3.part-number,
-  h3.chapter-number,
-  h3.back-matter-number {
+  .front-matter-number,
+  .part-number,
+  .chapter-number,
+  .back-matter-number {
     bookmark-level: none;
   }
 


### PR DESCRIPTION
This PR is part of https://github.com/pressbooks/pressbooks/issues/2443

Those elements are not an H3 anymore, I think it's better to leave as a class only they actually nested inside other tag

Note: This should be merged with https://github.com/pressbooks/pressbooks/pull/2457