### PR TITLE
Add screen-reader only labels for nav elements

### DIFF
--- a/header.php
+++ b/header.php
@@ -88,7 +88,8 @@
 			</div>
 			<div class="header__nav">
 				<a class="header__nav-icon js-header-nav-toggle" href="#navigation"><?php _e( 'Toggle Menu', 'pressbooks-book' ); ?><span class="header__nav-icon__icon"></span></a>
-				<nav class="js-header-nav" id="navigation">
+				<nav aria-labelledby="book-toc" class="js-header-nav" id="navigation">
+					<h2 id="book-toc" class="screen-reader-text">Book Contents Navigation</h2>
 					<ul id="nav-primary-menu" class="nav--primary">
 						<?php echo \PressbooksBook\Helpers\display_menu(); ?>
 					</ul>

--- a/header.php
+++ b/header.php
@@ -89,7 +89,7 @@
 			<div class="header__nav">
 				<a class="header__nav-icon js-header-nav-toggle" href="#navigation"><?php _e( 'Toggle Menu', 'pressbooks-book' ); ?><span class="header__nav-icon__icon"></span></a>
 				<nav aria-labelledby="book-toc" class="js-header-nav" id="navigation">
-					<h2 id="book-toc" class="screen-reader-text">Book Contents Navigation</h2>
+					<p id="book-toc" class="screen-reader-text">Book Contents Navigation</p>
 					<ul id="nav-primary-menu" class="nav--primary">
 						<?php echo \PressbooksBook\Helpers\display_menu(); ?>
 					</ul>

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -478,7 +478,7 @@ function get_links( $echo = true ) {
 	if ( $echo ) :
 		?>
 		<nav aria-labelledby="reading-nav" class="nav-reading <?php echo $multipage ? 'nav-reading--multipage' : '' ?>" role="navigation">
-		<h2 id="reading-nav" class="screen-reader-text">Previous/next navigation</h2>
+		<p id="reading-nav" class="screen-reader-text">Previous/next navigation</p>
 		<div class="nav-reading__previous js-nav-previous">
 			<?php if ( $prev_chapter !== '/' ) { ?>
 				<?php /* translators: %s: post title */ ?>

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -477,7 +477,8 @@ function get_links( $echo = true ) {
 
 	if ( $echo ) :
 		?>
-		<nav class="nav-reading <?php echo $multipage ? 'nav-reading--multipage' : '' ?>" role="navigation">
+		<nav aria-labelledby="reading-nav" class="nav-reading <?php echo $multipage ? 'nav-reading--multipage' : '' ?>" role="navigation">
+		<h2 id="reading-nav" class="screen-reader-text">Previous/next navigation</h2>
 		<div class="nav-reading__previous js-nav-previous">
 			<?php if ( $prev_chapter !== '/' ) { ?>
 				<?php /* translators: %s: post title */ ?>


### PR DESCRIPTION
Partial fix for https://github.com/pressbooks/pressbooks-book/issues/874. Accompanies https://github.com/pressbooks/pressbooks-aldine/pull/282