### PR TITLE
Fix buy links

### DIFF
--- a/.github/workflows/.pipeline.yml
+++ b/.github/workflows/.pipeline.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [ 7.3 ]
         os: [ ubuntu-18.04 ]
-        wordpress: [5.8, latest]
+        wordpress: [5.8.1, latest]
         experimental: [false]
         include:
           - php: 7.4
@@ -90,6 +90,7 @@ jobs:
 
       - name: Run Coverage
         run: composer require pcov/clobber; vendor/bin/pcov clobber; vendor/bin/phpunit --configuration phpunit.xml --coverage-clover coverage.xml
+        if: matrix.experimental == false
 
       - name: Run Frontend Tests
         run: |
@@ -102,6 +103,7 @@ jobs:
 
       - name: Upload Coverage to Codecov
         run: bash <(curl -s https://codecov.io/bash)
+        if: matrix.experimental == false
 
       - name: Prepare Build
         if: startsWith(github.ref, 'refs/tags/')

--- a/page-buy.php
+++ b/page-buy.php
@@ -40,11 +40,10 @@ get_header(); ?>
 						<li class="buy-kobo"><a href="<?php print $urls['kobo']; ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/kobo.png" width="54" height="29" alt="kobo-logo" title="Kobo"/></a><?php printf( __( 'Purchase on  <a href="%1$s">kobobooks.com</a>', 'pressbooks-book' ), $urls['kobo'] ); ?></li>
 					<?php endif; ?>
 
-						<?php if ( isset( $urls['ibooks'] ) && $urls['ibooks'] ) : ?>
+						<?php if ( isset( $urls['applebooks'] ) && $urls['applebooks'] ) : ?>
 							<?php /* translators: %1$s: url to purchase */ ?>
-						<li class="buy-ibooks"><a href="<?php print $urls['ibooks']; ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/ibooks.png" width="34" height="34" alt="ibooks-logo" title="iBook"/></a><?php printf( __( 'Purchase on  <a href="%1$s">apple.com</a>', 'pressbooks-book' ), $urls['ibooks'] ); ?></li>
+						<li class="buy-applebooks"><a href="<?php print $urls['applebooks']; ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/ibooks.png" width="34" height="34" alt="ibooks-logo" title="iBook"/></a><?php printf( __( 'Purchase on  <a href="%1$s">apple.com</a>', 'pressbooks-book' ), $urls['applebooks'] ); ?></li>
 					<?php endif; ?>
-
 						<?php if ( isset( $urls['otherservice'] ) && $urls['otherservice'] ) : ?>
 							<?php /* translators: %1$s: url to purchase */ ?>
 						<li class="buy-other"><?php _e( 'Purchase here:', 'pressbooks-book' ); ?> <a href="<?php print $urls['otherservice']; ?>"><?php print $urls['otherservice']; ?></a></li>


### PR DESCRIPTION
This PR replaces references to ibooks with applebooks on the buy book page. It accompanies https://github.com/pressbooks/pressbooks-book/pull/886.

It also includes minor tweaks to improve the CI pipeline.

To test:
1. Check out this branch and the `pb-2446-improve-publish` branch of Pressbooks 
2. Enter URL values for each of the available fields on a book's publish page
3. Visit the buy book link from the book's homepage
3. Check that the Apple books option displays as it did previously