### PR TITLE
fix: new semantic HTML selectors

### DIFF
--- a/.github/workflows/.pipeline.yml
+++ b/.github/workflows/.pipeline.yml
@@ -61,7 +61,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpcs, composer:v1, phpunit:, phpunit-polyfills
+          tools: phpcs, composer:v1
           coverage: pcov
 
       - name: Install Node dependencies
@@ -76,6 +76,8 @@ jobs:
         run: |
           export PATH="$HOME/.composer/vendor/bin:$PATH"
           composer install --no-interaction
+          composer global require "phpunit/phpunit:7.5.20"
+          composer require --dev yoast/phpunit-polyfills
 
       - name: Run Lint
         run: npm run lint

--- a/.github/workflows/.pipeline.yml
+++ b/.github/workflows/.pipeline.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [ 7.3 ]
         os: [ ubuntu-18.04 ]
-        wordpress: [5.8.1, 5.8.2]
+        wordpress: [5.8, latest]
         experimental: [false]
         include:
           - php: 7.4
@@ -61,7 +61,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpcs, composer:v1
+          tools: phpcs, composer:v1, phpunit-polyfills
           coverage: pcov
 
       - name: Install Node dependencies

--- a/.github/workflows/.pipeline.yml
+++ b/.github/workflows/.pipeline.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [ 7.3 ]
         os: [ ubuntu-18.04 ]
-        wordpress: [5.8, latest]
+        wordpress: [5.8.1, latest]
         experimental: [false]
         include:
           - php: 7.4

--- a/.github/workflows/.pipeline.yml
+++ b/.github/workflows/.pipeline.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [ 7.3 ]
         os: [ ubuntu-18.04 ]
-        wordpress: [5.8.1, latest]
+        wordpress: [5.8.1, 5.8.2]
         experimental: [false]
         include:
           - php: 7.4

--- a/.github/workflows/.pipeline.yml
+++ b/.github/workflows/.pipeline.yml
@@ -61,7 +61,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpcs, composer:v1, phpunit-polyfills
+          tools: phpcs, composer:v1, phpunit:, phpunit-polyfills
           coverage: pcov
 
       - name: Install Node dependencies
@@ -76,7 +76,6 @@ jobs:
         run: |
           export PATH="$HOME/.composer/vendor/bin:$PATH"
           composer install --no-interaction
-          composer global require "phpunit/phpunit:7.5.20"
 
       - name: Run Lint
         run: npm run lint

--- a/assets/legacy/styles/_epub-house-style.scss
+++ b/assets/legacy/styles/_epub-house-style.scss
@@ -59,7 +59,7 @@ display: none; */
 }
 
 .short-title,
-h6.short-title {
+p.short-title {
   display: none;
 }
 

--- a/assets/legacy/styles/_epub-house-style.scss
+++ b/assets/legacy/styles/_epub-house-style.scss
@@ -59,7 +59,7 @@ display: none; */
 }
 
 .short-title,
-p.short-title {
+h6.short-title {
   display: none;
 }
 

--- a/assets/legacy/styles/_epub-house-style.scss
+++ b/assets/legacy/styles/_epub-house-style.scss
@@ -71,7 +71,7 @@ h6.short-title {
 
 /* Numberless chapters have no chapter numbers */
 
-div.chapter.numberless h3.chapter-number {
+div.chapter.numberless .chapter-number {
   display: none;
 }
 

--- a/assets/legacy/styles/_mobi-house-style.scss
+++ b/assets/legacy/styles/_mobi-house-style.scss
@@ -7,11 +7,11 @@ Version:  2.0
 /* embedded fonts broken = ornament fonts broken, so replace them in KF8 */
 
 @media amzn-kf8 {
-  .chapter-title-wrap h2.chapter-title::before {
+  .chapter-title-wrap .chapter-title::before {
     content: "";
   }
 
-  .chapter-title-wrap h2.chapter-title::after {
+  .chapter-title-wrap .chapter-title::after {
     content: "";
   }
 

--- a/assets/legacy/styles/_mobi-house-style.scss
+++ b/assets/legacy/styles/_mobi-house-style.scss
@@ -362,17 +362,17 @@ Version:  2.0
     font-style: normal;
   }
 
-  p.author {
+  h3.author {
     font-weight: normal;
     font-style: normal;
   }
 
-  p.publisher {
+  h4.publisher {
     font-weight: normal;
     font-style: normal;
   }
 
-  p.publisher-city {
+  h5.publisher-city {
     font-weight: normal;
     font-style: normal;
   }
@@ -416,7 +416,7 @@ Version:  2.0
     text-align: center;
   }
 
-  p.part-number {
+  h3.part-number {
     font-weight: normal;
     font-style: normal;
     font-size: 1.3em;
@@ -434,7 +434,7 @@ Version:  2.0
     text-align: center;
   }
 
-  p.chapter-number {
+  h3.chapter-number {
     font-weight: normal;
     font-style: normal;
     font-size: 1.2em;
@@ -452,7 +452,7 @@ Version:  2.0
     text-align: center;
   }
 
-  p.chapter-subtitle {
+  h2.chapter-subtitle {
     font-weight: normal;
     font-style: normal;
     font-size: 0.9em;
@@ -461,7 +461,7 @@ Version:  2.0
     text-align: center;
   }
 
-  p.chapter-author {
+  h2.chapter-author {
     font-weight: normal;
     font-style: normal;
     font-size: 0.8em;

--- a/assets/legacy/styles/_mobi-house-style.scss
+++ b/assets/legacy/styles/_mobi-house-style.scss
@@ -7,7 +7,7 @@ Version:  2.0
 /* embedded fonts broken = ornament fonts broken, so replace them in KF8 */
 
 @media amzn-kf8 {
-  .chapter-title-wrap .chapter-title::before {
+  .chapter-title-wrap h2.chapter-title::before {
     content: "";
   }
 

--- a/assets/legacy/styles/_mobi-house-style.scss
+++ b/assets/legacy/styles/_mobi-house-style.scss
@@ -11,7 +11,7 @@ Version:  2.0
     content: "";
   }
 
-  .chapter-title-wrap .chapter-title::after {
+  .chapter-title-wrap h2.chapter-title::after {
     content: "";
   }
 

--- a/assets/legacy/styles/_mobi-house-style.scss
+++ b/assets/legacy/styles/_mobi-house-style.scss
@@ -362,17 +362,17 @@ Version:  2.0
     font-style: normal;
   }
 
-  h3.author {
+  p.author {
     font-weight: normal;
     font-style: normal;
   }
 
-  h4.publisher {
+  p.publisher {
     font-weight: normal;
     font-style: normal;
   }
 
-  h5.publisher-city {
+  p.publisher-city {
     font-weight: normal;
     font-style: normal;
   }
@@ -416,7 +416,7 @@ Version:  2.0
     text-align: center;
   }
 
-  h3.part-number {
+  p.part-number {
     font-weight: normal;
     font-style: normal;
     font-size: 1.3em;
@@ -434,7 +434,7 @@ Version:  2.0
     text-align: center;
   }
 
-  h3.chapter-number {
+  p.chapter-number {
     font-weight: normal;
     font-style: normal;
     font-size: 1.2em;
@@ -452,7 +452,7 @@ Version:  2.0
     text-align: center;
   }
 
-  h2.chapter-subtitle {
+  p.chapter-subtitle {
     font-weight: normal;
     font-style: normal;
     font-size: 0.9em;
@@ -461,7 +461,7 @@ Version:  2.0
     text-align: center;
   }
 
-  h2.chapter-author {
+  p.chapter-author {
     font-weight: normal;
     font-style: normal;
     font-size: 0.8em;

--- a/assets/legacy/styles/_pdf-house-style.scss
+++ b/assets/legacy/styles/_pdf-house-style.scss
@@ -752,7 +752,7 @@ meta[name="pb-publisher-city"] {
 
 /* PART & CHAPTER STRINGS */
 
-.part-title-wrap h3.part-number {
+.part-title-wrap .part-number {
   string-set: part-number content();
 }
 
@@ -760,11 +760,11 @@ meta[name="pb-publisher-city"] {
   string-set: part-title content();
 }
 
-h3.chapter-number {
+.chapter-number {
   string-set: chapter-number content();
 }
 
-div.chapter.numberless h3.chapter-number {
+div.chapter.numberless .chapter-number {
   display: none;
 }
 
@@ -778,9 +778,9 @@ div.back-matter .back-matter-title-wrap > h1:first-of-type {
 /* "short title override" ... this sets short chapter title content (for running header) but does not display it.
 it can cause problems with spacing of things, so be careful to design around it */
 
-div.front-matter > div.ugc h6.short-title:first-of-type,
-div.chapter > div.ugc h6.short-title:first-of-type,
-div.back-matter > div.ugc h6.short-title:first-of-type {
+div.front-matter > div.ugc .short-title:first-of-type,
+div.chapter > div.ugc .short-title:first-of-type,
+div.back-matter > div.ugc .short-title:first-of-type {
   string-set: section-title content() !important; /* override running header */
   visibility: hidden; /* display:none breaks string-set: */
   font-size: 0;

--- a/assets/legacy/styles/_pdf-house-style.scss
+++ b/assets/legacy/styles/_pdf-house-style.scss
@@ -752,7 +752,7 @@ meta[name="pb-publisher-city"] {
 
 /* PART & CHAPTER STRINGS */
 
-.part-title-wrap p.part-number {
+.part-title-wrap h3.part-number {
   string-set: part-number content();
 }
 
@@ -760,11 +760,11 @@ meta[name="pb-publisher-city"] {
   string-set: part-title content();
 }
 
-p.chapter-number {
+h3.chapter-number {
   string-set: chapter-number content();
 }
 
-div.chapter.numberless p.chapter-number {
+div.chapter.numberless h3.chapter-number {
   display: none;
 }
 
@@ -778,20 +778,20 @@ div.back-matter .back-matter-title-wrap > h1:first-of-type {
 /* "short title override" ... this sets short chapter title content (for running header) but does not display it.
 it can cause problems with spacing of things, so be careful to design around it */
 
-div.front-matter > div.ugc p.short-title:first-of-type,
-div.chapter > div.ugc p.short-title:first-of-type,
-div.back-matter > div.ugc p.short-title:first-of-type {
+div.front-matter > div.ugc h6.short-title:first-of-type,
+div.chapter > div.ugc h6.short-title:first-of-type,
+div.back-matter > div.ugc h6.short-title:first-of-type {
   string-set: section-title content() !important; /* override running header */
   visibility: hidden; /* display:none breaks string-set: */
   font-size: 0;
   height: 0;
 }
 
-div.ugc p.chapter-author {
+div.ugc h2.chapter-author {
   string-set: chapter-author content();
 }
 
-div.ugc p.chapter-subtitle {
+div.ugc h2.chapter-subtitle {
   string-set: chapter-subtitle content();
 }
 

--- a/assets/legacy/styles/_pdf-house-style.scss
+++ b/assets/legacy/styles/_pdf-house-style.scss
@@ -752,7 +752,7 @@ meta[name="pb-publisher-city"] {
 
 /* PART & CHAPTER STRINGS */
 
-.part-title-wrap h3.part-number {
+.part-title-wrap p.part-number {
   string-set: part-number content();
 }
 
@@ -760,11 +760,11 @@ meta[name="pb-publisher-city"] {
   string-set: part-title content();
 }
 
-h3.chapter-number {
+p.chapter-number {
   string-set: chapter-number content();
 }
 
-div.chapter.numberless h3.chapter-number {
+div.chapter.numberless p.chapter-number {
   display: none;
 }
 
@@ -778,20 +778,20 @@ div.back-matter .back-matter-title-wrap > h1:first-of-type {
 /* "short title override" ... this sets short chapter title content (for running header) but does not display it.
 it can cause problems with spacing of things, so be careful to design around it */
 
-div.front-matter > div.ugc h6.short-title:first-of-type,
-div.chapter > div.ugc h6.short-title:first-of-type,
-div.back-matter > div.ugc h6.short-title:first-of-type {
+div.front-matter > div.ugc p.short-title:first-of-type,
+div.chapter > div.ugc p.short-title:first-of-type,
+div.back-matter > div.ugc p.short-title:first-of-type {
   string-set: section-title content() !important; /* override running header */
   visibility: hidden; /* display:none breaks string-set: */
   font-size: 0;
   height: 0;
 }
 
-div.ugc h2.chapter-author {
+div.ugc p.chapter-author {
   string-set: chapter-author content();
 }
 
-div.ugc h2.chapter-subtitle {
+div.ugc p.chapter-subtitle {
   string-set: chapter-subtitle content();
 }
 

--- a/assets/legacy/styles/_prince-toc.scss
+++ b/assets/legacy/styles/_prince-toc.scss
@@ -158,6 +158,7 @@
     display: inline-block;
     width: 75%;
     text-indent: 0;
+    color: inherit;
   }
 
   /* TOC CHAPTER NUMBERS */
@@ -610,6 +611,7 @@
     display: none;
     width: 75%;
     text-indent: 0;
+    color: inherit;
   }
 
   /* TOC CHAPTER NUMBERS */

--- a/composer.lock
+++ b/composer.lock
@@ -1747,7 +1747,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -2733,12 +2732,12 @@
             "version": "0.14.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
                 "reference": "cf6b310caad735816caef7573295f8a534374706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
                 "reference": "cf6b310caad735816caef7573295f8a534374706",
                 "shasum": ""
             },

--- a/packages/buckram/assets/styles/components/_colors.scss
+++ b/packages/buckram/assets/styles/components/_colors.scss
@@ -167,7 +167,7 @@ h1.front-matter-title {
 }
 
 // PART TITLE COLOR
-p.part-number {
+.part-number {
   color: if-map-get($part-number-color, $type);
 }
 
@@ -185,11 +185,11 @@ h2.chapter-title {
   color: if-map-get($chapter-title-color, $type);
 }
 
-p.chapter-subtitle {
+.chapter-subtitle {
   color: if-map-get($chapter-subtitle-color, $type);
 }
 
-p.chapter-author {
+.chapter-author {
   color: if-map-get($chapter-author-color, $type);
 }
 

--- a/packages/buckram/assets/styles/components/_colors.scss
+++ b/packages/buckram/assets/styles/components/_colors.scss
@@ -125,7 +125,7 @@ p.wp-caption-text {
 }
 
 // TITLE PAGE(S) COLOR
-#half-title-page > h1.title {
+#half-title-page > .title {
   color: if-map-get($half-title-title-color, $type);
 }
 

--- a/packages/buckram/assets/styles/components/_colors.scss
+++ b/packages/buckram/assets/styles/components/_colors.scss
@@ -150,7 +150,7 @@ p.wp-caption-text {
 }
 
 // FRONT MATTER COLOR
-h1.front-matter-title {
+.front-matter-title {
   color: if-map-get($front-matter-title-color, $type);
 }
 
@@ -171,7 +171,7 @@ h1.front-matter-title {
   color: if-map-get($part-number-color, $type);
 }
 
-h1.part-title {
+.part-title {
   color: if-map-get($part-title-color, $type);
 }
 
@@ -181,7 +181,7 @@ h1.part-title {
   color: if-map-get($chapter-number-color, $type);
 }
 
-h2.chapter-title {
+.chapter-title {
   color: if-map-get($chapter-title-color, $type);
 }
 
@@ -198,7 +198,7 @@ h2.chapter-title {
 }
 
 // BACK MATTER TITLE COLOR
-h1.back-matter-title {
+.back-matter-title {
   color: if-map-get($back-matter-title-color, $type);
 }
 

--- a/packages/buckram/assets/styles/components/_colors.scss
+++ b/packages/buckram/assets/styles/components/_colors.scss
@@ -167,7 +167,7 @@ h1.front-matter-title {
 }
 
 // PART TITLE COLOR
-h3.part-number {
+p.part-number {
   color: if-map-get($part-number-color, $type);
 }
 
@@ -185,11 +185,11 @@ h2.chapter-title {
   color: if-map-get($chapter-title-color, $type);
 }
 
-h2.chapter-subtitle {
+p.chapter-subtitle {
   color: if-map-get($chapter-subtitle-color, $type);
 }
 
-h2.chapter-author {
+p.chapter-author {
   color: if-map-get($chapter-author-color, $type);
 }
 

--- a/packages/buckram/assets/styles/components/pages/_titles.scss
+++ b/packages/buckram/assets/styles/components/pages/_titles.scss
@@ -90,6 +90,7 @@
   word-spacing: $title-author-word-spacing;
   text-align: $title-author-align;
   text-transform: $title-author-text-transform;
+  text-indent: 0;
   border-bottom: if-map-get($title-author-border-bottom-width, $type) $title-author-border-bottom-style if-map-get($title-author-border-bottom-color, $type);
   padding-bottom: if-map-get($title-author-padding-bottom, $type);
   @if $type != 'epub' {
@@ -124,6 +125,7 @@ div.publisher-logo {
   word-spacing: $title-publisher-word-spacing;
   text-align: $title-publisher-align;
   text-transform: $title-publisher-text-transform;
+  text-indent: 0;
   border-bottom: if-map-get($title-publisher-border-bottom-width, $type) $title-publisher-border-bottom-style if-map-get($title-publisher-border-bottom-color, $type);
   padding-bottom: if-map-get($title-publisher-padding-bottom, $type);
 }
@@ -145,11 +147,12 @@ div.publisher-logo {
   word-spacing: $title-publisher-city-word-spacing;
   text-align: $title-publisher-city-align;
   text-transform: $title-publisher-city-text-transform;
+  text-indent: 0;
   border-bottom: if-map-get($title-publisher-city-border-bottom-width, $type) $title-publisher-city-border-bottom-style if-map-get($title-publisher-city-border-bottom-color, $type);
   padding-bottom: if-map-get($title-publisher-city-padding-bottom, $type);
 }
 
-// Prince and EPUB-specific disply rules
+// Prince and EPUB-specific display rules
 @mixin titles-prince {
   #title-page {
     > .subtitle,

--- a/packages/buckram/assets/styles/components/pages/_titles.scss
+++ b/packages/buckram/assets/styles/components/pages/_titles.scss
@@ -77,7 +77,7 @@ h2.subtitle {
   }
 }
 
-p.author {
+.author {
   margin-top: if-map-get($title-author-margin-top, $type);
   margin-right: if-map-get($title-author-margin-right, $type);
   margin-left: if-map-get($title-author-margin-left, $type);
@@ -108,7 +108,7 @@ div.publisher-logo {
   text-align: $title-publisher-logo-text-align;
 }
 
-p.publisher {
+.publisher {
   display: block;
   float: if-map-get($title-publisher-float, $type);
   margin: if-map-get($title-publisher-margin-top, $type) if-map-get($title-publisher-margin-right, $type) if-map-get($title-publisher-margin-bottom, $type) if-map-get($title-publisher-margin-left, $type);
@@ -128,7 +128,7 @@ p.publisher {
   padding-bottom: if-map-get($title-publisher-padding-bottom, $type);
 }
 
-p.publisher-city {
+.publisher-city {
   float: if-map-get($title-publisher-city-float, $type);
   margin-top: 0;
   margin-left: if-map-get($title-publisher-city-margin-left, $type);
@@ -191,17 +191,17 @@ p.publisher-city {
       font-weight: normal;
     }
 
-    p.author {
+    .author {
       font-style: normal;
       font-weight: normal;
     }
 
-    p.publisher {
+    .publisher {
       font-style: normal;
       font-weight: normal;
     }
 
-    p.publisher-city {
+    .publisher-city {
       font-style: normal;
       font-weight: normal;
     }

--- a/packages/buckram/assets/styles/components/pages/_titles.scss
+++ b/packages/buckram/assets/styles/components/pages/_titles.scss
@@ -77,7 +77,7 @@ h2.subtitle {
   }
 }
 
-h3.author {
+p.author {
   margin-top: if-map-get($title-author-margin-top, $type);
   margin-right: if-map-get($title-author-margin-right, $type);
   margin-left: if-map-get($title-author-margin-left, $type);
@@ -108,7 +108,7 @@ div.publisher-logo {
   text-align: $title-publisher-logo-text-align;
 }
 
-h4.publisher {
+p.publisher {
   display: block;
   float: if-map-get($title-publisher-float, $type);
   margin: if-map-get($title-publisher-margin-top, $type) if-map-get($title-publisher-margin-right, $type) if-map-get($title-publisher-margin-bottom, $type) if-map-get($title-publisher-margin-left, $type);
@@ -128,7 +128,7 @@ h4.publisher {
   padding-bottom: if-map-get($title-publisher-padding-bottom, $type);
 }
 
-h5.publisher-city {
+p.publisher-city {
   float: if-map-get($title-publisher-city-float, $type);
   margin-top: 0;
   margin-left: if-map-get($title-publisher-city-margin-left, $type);
@@ -191,17 +191,17 @@ h5.publisher-city {
       font-weight: normal;
     }
 
-    h3.author {
+    p.author {
       font-style: normal;
       font-weight: normal;
     }
 
-    h4.publisher {
+    p.publisher {
       font-style: normal;
       font-weight: normal;
     }
 
-    h5.publisher-city {
+    p.publisher-city {
       font-style: normal;
       font-weight: normal;
     }

--- a/packages/buckram/assets/styles/components/pages/_titles.scss
+++ b/packages/buckram/assets/styles/components/pages/_titles.scss
@@ -9,7 +9,7 @@
   display: if-map-get($title-half-title-display, $type);
 }
 
-#half-title-page > h1.title {
+#half-title-page > .title {
   margin-top: if-map-get($title-half-title-block-margin-top, $type);
   font-family: $title-half-title-font-family;
   font-size: if-map-get($title-half-title-font-size, $type);
@@ -23,7 +23,7 @@
 }
 
 // Title Page
-h1.title {
+.title {
   margin-top: if-map-get($title-title-margin-top, $type);
   margin-right: if-map-get($title-title-margin-right, $type);
   margin-left: if-map-get($title-title-margin-left, $type);
@@ -57,7 +57,7 @@ h1.title {
   }
 }
 
-h2.subtitle {
+.subtitle {
   margin-top: if-map-get($title-subtitle-margin-top, $type);
   margin-right: if-map-get($title-subtitle-margin-right, $type);
   margin-left: if-map-get($title-subtitle-margin-left, $type);
@@ -168,24 +168,24 @@ div.publisher-logo {
 
 @if $type == 'epub' {
   @media amzn-kf8 {
-    #title-page h1.title::before {
+    #title-page .title::before {
       content: '';
     }
 
-    #title-page h1.title::after {
+    #title-page .title::after {
       content: '';
     }
   }
 
   @media amzn-mobi {
-    h1.title {
+    .title {
       margin-top: 2em;
       font-size: 2em;
       font-style: normal;
       font-weight: normal;
     }
 
-    h2.subtitle {
+    .subtitle {
       font-size: 1em;
       font-style: normal;
       font-weight: normal;

--- a/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
@@ -46,7 +46,7 @@
       }
     }
 
-    p.chapter-subtitle {
+    .chapter-subtitle {
       display: block;
       margin-bottom: 0;
       font-family: $section-subtitle-font-family;
@@ -63,7 +63,7 @@
       word-spacing: if-map-get($section-subtitle-word-spacing, $type);
     }
 
-    p.chapter-author {
+    .chapter-author {
       display: block;
       margin-bottom: if-map-get($section-author-margin-bottom, $type);
       font-family: $section-author-font-family;
@@ -78,17 +78,17 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h1.back-matter-title + p.chapter-subtitle,
+    h1.back-matter-title + .chapter-subtitle,
     .short-title + p.chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
 
-    h1.back-matter-title + p.chapter-author,
+    h1.back-matter-title + .chapter-author,
     .short-title + p.chapter-author {
       margin-top: if-map-get($section-title-author-spacing, $type);
     }
 
-    p.chapter-subtitle + p.chapter-author {
+    .chapter-subtitle + .chapter-author {
       margin-top: if-map-get($section-subtitle-author-spacing, $type);
     }
 
@@ -96,7 +96,7 @@
       margin-bottom: if-map-get($back-matter-title-margin-bottom, $type);
     }
 
-    p.chapter-subtitle:last-child {
+    .chapter-subtitle:last-child {
       margin-bottom: if-map-get($section-subtitle-margin-bottom, $type);
     }
   }

--- a/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
@@ -12,7 +12,7 @@
       display: none;
     }
 
-    h1.back-matter-title {
+    .back-matter-title {
       display: block;
       margin-top: if-map-get($back-matter-title-margin-top, $type);
       margin-bottom: 0;
@@ -78,13 +78,13 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h1.back-matter-title + .chapter-subtitle,
-    .short-title + p.chapter-subtitle {
+    .back-matter-title + .chapter-subtitle,
+    .short-title + .chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
 
-    h1.back-matter-title + .chapter-author,
-    .short-title + p.chapter-author {
+    .back-matter-title + .chapter-author,
+    .short-title + .chapter-author {
       margin-top: if-map-get($section-title-author-spacing, $type);
     }
 
@@ -92,7 +92,7 @@
       margin-top: if-map-get($section-subtitle-author-spacing, $type);
     }
 
-    h1.back-matter-title:last-child {
+    .back-matter-title:last-child {
       margin-bottom: if-map-get($back-matter-title-margin-bottom, $type);
     }
 
@@ -104,7 +104,7 @@
 
 @if $type == 'epub' {
   @media amzn-mobi {
-    h2.back-matter-title {
+    .back-matter-title {
       margin-top: 1em;
       margin-bottom: 1em;
       font-size: 1.3em;

--- a/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
@@ -46,7 +46,7 @@
       }
     }
 
-    h2.chapter-subtitle {
+    p.chapter-subtitle {
       display: block;
       margin-bottom: 0;
       font-family: $section-subtitle-font-family;
@@ -63,7 +63,7 @@
       word-spacing: if-map-get($section-subtitle-word-spacing, $type);
     }
 
-    h2.chapter-author {
+    p.chapter-author {
       display: block;
       margin-bottom: if-map-get($section-author-margin-bottom, $type);
       font-family: $section-author-font-family;
@@ -78,17 +78,17 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h1.back-matter-title + h2.chapter-subtitle,
-    .short-title + h2.chapter-subtitle {
+    h1.back-matter-title + p.chapter-subtitle,
+    .short-title + p.chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
 
-    h1.back-matter-title + h2.chapter-author,
-    .short-title + h2.chapter-author {
+    h1.back-matter-title + p.chapter-author,
+    .short-title + p.chapter-author {
       margin-top: if-map-get($section-title-author-spacing, $type);
     }
 
-    h2.chapter-subtitle + h2.chapter-author {
+    p.chapter-subtitle + p.chapter-author {
       margin-top: if-map-get($section-subtitle-author-spacing, $type);
     }
 
@@ -96,7 +96,7 @@
       margin-bottom: if-map-get($back-matter-title-margin-bottom, $type);
     }
 
-    h2.chapter-subtitle:last-child {
+    p.chapter-subtitle:last-child {
       margin-bottom: if-map-get($section-subtitle-margin-bottom, $type);
     }
   }

--- a/packages/buckram/assets/styles/components/section-titles/_chapters.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_chapters.scss
@@ -82,7 +82,7 @@
       }
     }
 
-    p.chapter-subtitle {
+    .chapter-subtitle {
       display: block;
       margin-bottom: 0;
       font-family: $section-subtitle-font-family;
@@ -99,7 +99,7 @@
       word-spacing: if-map-get($section-subtitle-word-spacing, $type);
     }
 
-    p.chapter-author {
+    .chapter-author {
       display: block;
       margin-bottom: if-map-get($section-author-margin-bottom, $type);
       font-family: $section-author-font-family;
@@ -114,25 +114,25 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h2.chapter-title + p.chapter-subtitle,
-    .short-title + p.chapter-subtitle {
+    h2.chapter-title + .chapter-subtitle,
+    .short-title + .chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
 
-    p.chapter-title + p.chapter-author,
-    .short-title + p.chapter-author {
+    .chapter-title + .chapter-author,
+    .short-title + .chapter-author {
       margin-top: if-map-get($section-title-author-spacing, $type);
     }
 
-    p.chapter-subtitle + p.chapter-author {
+    .chapter-subtitle + .chapter-author {
       margin-top: if-map-get($section-subtitle-author-spacing, $type);
     }
 
-    p.chapter-title:last-child {
+    .chapter-title:last-child {
       margin-bottom: if-map-get($section-title-margin-bottom, $type);
     }
 
-    p.chapter-subtitle:last-child {
+    .chapter-subtitle:last-child {
       margin-bottom: if-map-get($section-subtitle-margin-bottom, $type);
     }
   }
@@ -195,7 +195,7 @@ blockquote.aphorism {
       text-align: center;
     }
 
-    p.chapter-subtitle {
+    .chapter-subtitle {
       margin-top: 0.5em;
       margin-bottom: 0.5em;
       font-size: 0.9em;
@@ -204,7 +204,7 @@ blockquote.aphorism {
       text-align: center;
     }
 
-    p.chapter-author {
+    .chapter-author {
       margin-top: 0.5em;
       margin-bottom: 0.5em;
       font-size: 0.8em;

--- a/packages/buckram/assets/styles/components/section-titles/_chapters.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_chapters.scss
@@ -8,7 +8,7 @@
   .chapter-title-wrap {
     margin: if-map-get($section-header-margin-top, $type) if-map-get($section-header-margin-right, $type) if-map-get($section-header-margin-bottom, $type) if-map-get($section-header-margin-left, $type);
 
-    h2.chapter-title {
+    .chapter-title {
       border-bottom: if-map-get($chapter-title-border-bottom-width, $type) $chapter-title-border-bottom-style if-map-get($chapter-title-border-bottom-color, $type);
       padding-bottom: if-map-get($chapter-title-padding-bottom, $type);
       display: $chapter-title-display;
@@ -114,7 +114,7 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h2.chapter-title + .chapter-subtitle,
+    .chapter-title + .chapter-subtitle,
     .short-title + .chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
@@ -177,7 +177,7 @@ blockquote.aphorism {
       margin-bottom: 0;
     }
 
-    p.chapter-number {
+    .chapter-number {
       margin-top: 1em;
       margin-bottom: 1em;
       font-size: 1.2em;
@@ -186,7 +186,7 @@ blockquote.aphorism {
       text-align: center;
     }
 
-    h2.chapter-title {
+    .chapter-title {
       margin-top: 1em;
       margin-bottom: 1em;
       font-size: 1.5em;
@@ -215,11 +215,11 @@ blockquote.aphorism {
   }
 
   @media amzn-kf8 {
-    .chapter-title-wrap h2.chapter-title::before {
+    .chapter-title-wrap .chapter-title::before {
       content: '';
     }
 
-    .chapter-title-wrap h2.chapter-title::after {
+    .chapter-title-wrap .chapter-title::after {
       content: '';
     }
   }

--- a/packages/buckram/assets/styles/components/section-titles/_chapters.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_chapters.scss
@@ -82,7 +82,7 @@
       }
     }
 
-    h2.chapter-subtitle {
+    p.chapter-subtitle {
       display: block;
       margin-bottom: 0;
       font-family: $section-subtitle-font-family;
@@ -99,7 +99,7 @@
       word-spacing: if-map-get($section-subtitle-word-spacing, $type);
     }
 
-    h2.chapter-author {
+    p.chapter-author {
       display: block;
       margin-bottom: if-map-get($section-author-margin-bottom, $type);
       font-family: $section-author-font-family;
@@ -114,25 +114,25 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h2.chapter-title + h2.chapter-subtitle,
-    .short-title + h2.chapter-subtitle {
+    h2.chapter-title + p.chapter-subtitle,
+    .short-title + p.chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
 
-    h2.chapter-title + h2.chapter-author,
-    .short-title + h2.chapter-author {
+    p.chapter-title + p.chapter-author,
+    .short-title + p.chapter-author {
       margin-top: if-map-get($section-title-author-spacing, $type);
     }
 
-    h2.chapter-subtitle + h2.chapter-author {
+    p.chapter-subtitle + p.chapter-author {
       margin-top: if-map-get($section-subtitle-author-spacing, $type);
     }
 
-    h2.chapter-title:last-child {
+    p.chapter-title:last-child {
       margin-bottom: if-map-get($section-title-margin-bottom, $type);
     }
 
-    h2.chapter-subtitle:last-child {
+    p.chapter-subtitle:last-child {
       margin-bottom: if-map-get($section-subtitle-margin-bottom, $type);
     }
   }
@@ -177,7 +177,7 @@ blockquote.aphorism {
       margin-bottom: 0;
     }
 
-    h3.chapter-number {
+    p.chapter-number {
       margin-top: 1em;
       margin-bottom: 1em;
       font-size: 1.2em;
@@ -195,7 +195,7 @@ blockquote.aphorism {
       text-align: center;
     }
 
-    h2.chapter-subtitle {
+    p.chapter-subtitle {
       margin-top: 0.5em;
       margin-bottom: 0.5em;
       font-size: 0.9em;
@@ -204,7 +204,7 @@ blockquote.aphorism {
       text-align: center;
     }
 
-    h2.chapter-author {
+    p.chapter-author {
       margin-top: 0.5em;
       margin-bottom: 0.5em;
       font-size: 0.8em;

--- a/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
@@ -46,7 +46,7 @@
       }
     }
 
-    h2.chapter-subtitle {
+    p.chapter-subtitle {
       display: block;
       margin-bottom: 0;
       font-family: $section-subtitle-font-family;
@@ -63,7 +63,7 @@
       word-spacing: if-map-get($section-subtitle-word-spacing, $type);
     }
 
-    h2.chapter-author {
+    p.chapter-author {
       display: block;
       margin-bottom: if-map-get($section-author-margin-bottom, $type);
       font-family: $section-author-font-family;
@@ -78,17 +78,17 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h1.front-matter-title + h2.chapter-subtitle,
-    .short-title + h2.chapter-subtitle {
+    h1.front-matter-title + p.chapter-subtitle,
+    .short-title + p.chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
 
-    h1.front-matter-title + h2.chapter-author,
-    .short-title + h2.chapter-author {
+    h1.front-matter-title + p.chapter-author,
+    .short-title + p.chapter-author {
       margin-top: if-map-get($section-title-author-spacing, $type);
     }
 
-    h2.chapter-subtitle + h2.chapter-author {
+    p.chapter-subtitle + p.chapter-author {
       margin-top: if-map-get($section-subtitle-author-spacing, $type);
     }
 
@@ -96,7 +96,7 @@
       margin-bottom: if-map-get($front-matter-title-margin-bottom, $type);
     }
 
-    h2.chapter-subtitle:last-child {
+    p.chapter-subtitle:last-child {
       margin-bottom: if-map-get($section-subtitle-margin-bottom, $type);
     }
   }

--- a/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
@@ -46,7 +46,7 @@
       }
     }
 
-    p.chapter-subtitle {
+    .chapter-subtitle {
       display: block;
       margin-bottom: 0;
       font-family: $section-subtitle-font-family;
@@ -63,7 +63,7 @@
       word-spacing: if-map-get($section-subtitle-word-spacing, $type);
     }
 
-    p.chapter-author {
+    .chapter-author {
       display: block;
       margin-bottom: if-map-get($section-author-margin-bottom, $type);
       font-family: $section-author-font-family;
@@ -78,17 +78,17 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h1.front-matter-title + p.chapter-subtitle,
-    .short-title + p.chapter-subtitle {
+    h1.front-matter-title + .chapter-subtitle,
+    .short-title + .chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
 
-    h1.front-matter-title + p.chapter-author,
-    .short-title + p.chapter-author {
+    h1.front-matter-title + .chapter-author,
+    .short-title + .chapter-author {
       margin-top: if-map-get($section-title-author-spacing, $type);
     }
 
-    p.chapter-subtitle + p.chapter-author {
+    .chapter-subtitle + .chapter-author {
       margin-top: if-map-get($section-subtitle-author-spacing, $type);
     }
 
@@ -96,7 +96,7 @@
       margin-bottom: if-map-get($front-matter-title-margin-bottom, $type);
     }
 
-    p.chapter-subtitle:last-child {
+    .chapter-subtitle:last-child {
       margin-bottom: if-map-get($section-subtitle-margin-bottom, $type);
     }
   }

--- a/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
@@ -12,7 +12,7 @@
       display: none;
     }
 
-    h1.front-matter-title {
+    .front-matter-title {
       display: block;
       margin-top: if-map-get($front-matter-title-margin-top, $type);
       margin-bottom: 0;
@@ -78,12 +78,12 @@
       word-spacing: if-map-get($section-author-word-spacing, $type);
     }
 
-    h1.front-matter-title + .chapter-subtitle,
+    .front-matter-title + .chapter-subtitle,
     .short-title + .chapter-subtitle {
       margin-top: if-map-get($section-title-subtitle-spacing, $type);
     }
 
-    h1.front-matter-title + .chapter-author,
+    .front-matter-title + .chapter-author,
     .short-title + .chapter-author {
       margin-top: if-map-get($section-title-author-spacing, $type);
     }
@@ -92,7 +92,7 @@
       margin-top: if-map-get($section-subtitle-author-spacing, $type);
     }
 
-    h1.front-matter-title:last-child {
+    .front-matter-title:last-child {
       margin-bottom: if-map-get($front-matter-title-margin-bottom, $type);
     }
 
@@ -137,7 +137,7 @@
 
 @if $type == 'epub' {
   @media amzn-mobi {
-    h1.front-matter-title {
+    .front-matter-title {
       margin-top: 1em;
       margin-bottom: 1em;
       font-size: 1.4em;

--- a/packages/buckram/assets/styles/components/section-titles/_parts.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_parts.scss
@@ -71,7 +71,7 @@
 
 @if $type == 'epub' {
   @media amzn-mobi {
-    h3.part-number {
+    p.part-number {
       margin-top: 1em;
       margin-bottom: 1em;
       font-size: 1.3em;

--- a/packages/buckram/assets/styles/components/section-titles/_parts.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_parts.scss
@@ -71,7 +71,7 @@
 
 @if $type == 'epub' {
   @media amzn-mobi {
-    p.part-number {
+    .part-number {
       margin-top: 1em;
       margin-bottom: 1em;
       font-size: 1.3em;

--- a/packages/buckram/assets/styles/components/section-titles/_parts.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_parts.scss
@@ -80,7 +80,7 @@
       text-align: center;
     }
 
-    h1.part-title {
+    .part-title {
       margin-top: 1em;
       margin-bottom: 1em;
       font-size: 1.4em;

--- a/packages/buckram/assets/styles/components/toc/_generic.scss
+++ b/packages/buckram/assets/styles/components/toc/_generic.scss
@@ -219,13 +219,7 @@
 }
 
 @if $type == 'prince' {
-  p.front-matter-number,
-  p.part-number,
-  p.chapter-number,
-  p.back-matter-number {
-    bookmark-level: none;
-  }
-
+  
   #toc {
     display: $toc-display;
     counter-reset: part;

--- a/packages/buckram/assets/styles/components/toc/_generic.scss
+++ b/packages/buckram/assets/styles/components/toc/_generic.scss
@@ -219,10 +219,10 @@
 }
 
 @if $type == 'prince' {
-  h3.front-matter-number,
-  h3.part-number,
-  h3.chapter-number,
-  h3.back-matter-number {
+  p.front-matter-number,
+  p.part-number,
+  p.chapter-number,
+  p.back-matter-number {
     bookmark-level: none;
   }
 

--- a/packages/buckram/assets/styles/components/toc/_generic.scss
+++ b/packages/buckram/assets/styles/components/toc/_generic.scss
@@ -33,14 +33,10 @@
       text-indent: 0;
     }
 
-    .chapter-subtitle {
+    .chapter-subtitle, .chapter-author {
       hyphens: none;
       text-indent: 0;
-    }
-
-    .chapter-author {
-      hyphens: none;
-      text-indent: 0;
+      color: inherit;
     }
 
     .chapter-license {
@@ -219,7 +215,7 @@
 }
 
 @if $type == 'prince' {
-  
+
   #toc {
     display: $toc-display;
     counter-reset: part;

--- a/packages/buckram/assets/styles/variables/_pages.scss
+++ b/packages/buckram/assets/styles/variables/_pages.scss
@@ -255,7 +255,7 @@ $title-subtitle-line-height: $title-title-line-height !default;
 
 // Author
 
-/// Top margin for title page author on elements `<h3>` with a class of `author`.
+/// Top margin for title page author on elements with a class of `author`.
 /// @type String | Map
 $title-author-margin-top: (
   epub: 2em,
@@ -263,21 +263,21 @@ $title-author-margin-top: (
   web: 2em
 ) !default;
 
-/// Right margin for title page author on elements `<h3>` with a class of `author`.
+/// Right margin for title page author on elements with a class of `author`.
 /// @type String | Map
 /// @since 1.0.0
 $title-author-margin-right: 0 !default;
 
-/// Left margin for title page author on elements `<h3>` with a class of `author`.
+/// Left margin for title page author on elements with a class of `author`.
 /// @type String | Map
 /// @since 1.0.0
 $title-author-margin-left: 0 !default;
 
-/// Font stack for title page author on elements `<h3>` with a class of `author`.
+/// Font stack for title page author on elements with a class of `author`.
 /// @type String
 $title-author-font-family: $font-2 !default;
 
-/// Font size for title page author on elements `<h3>` with a class of `author`.
+/// Font size for title page author on elements with a class of `author`.
 /// @type String | Map
 $title-author-font-size:(
   epub: 1em,
@@ -285,27 +285,27 @@ $title-author-font-size:(
   web: 1em
 ) !default;
 
-/// Font style for title page author on elements `<h3>` with a class of `author`.
+/// Font style for title page author on elements with a class of `author`.
 /// @type String
 $title-author-font-style: normal !default;
 
-/// Font weight for title page author on elements `<h3>` with a class of `author`.
+/// Font weight for title page author on elements with a class of `author`.
 /// @type String
 $title-author-font-weight: normal !default;
 
-/// Letter spacing for title page author on elements `<h3>` with a class of `author`.
+/// Letter spacing for title page author on elements with a class of `author`.
 /// @type String
 $title-author-letter-spacing: 1px !default;
 
-/// Word spacing for title page author on elements `<h3>` with a class of `author`.
+/// Word spacing for title page author on elements with a class of `author`.
 /// @type String
 $title-author-word-spacing: 2px !default;
 
-/// Text alignment for title page author on elements `<h3>` with a class of `author`.
+/// Text alignment for title page author on elements with a class of `author`.
 /// @type String
 $title-author-align: center !default;
 
-/// Text transform for title page author on elements `<h3>` with a class of `author`.
+/// Text transform for title page author on elements with a class of `author`.
 /// @type String
 $title-author-text-transform: none !default;
 
@@ -366,64 +366,64 @@ $title-publisher-logo-margin-left: auto !default;
 
 // Publisher
 
-/// Top margin for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Top margin for title page publisher text on elements with a class of `publisher`.
 /// @type String | Map
 /// @since 1.2.0
-$title-publisher-margin-top: (epub: 0, prince: 0, web: 0) !default;
+$title-publisher-margin-top: (epub: 1.5em, prince: 1.5em, web: 0) !default;
 
-/// Right margin for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Right margin for title page publisher text on elements with a class of `publisher`.
 /// @type String | Map
 /// @since 1.2.0
 $title-publisher-margin-right: (epub: 0, prince: 0, web: 0) !default;
 
-/// Bottom margin for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Bottom margin for title page publisher text on elements with a class of `publisher`.
 /// @type String | Map
 /// @since 1.2.0
 $title-publisher-margin-bottom: (epub: 0.5em, prince: 0.5em, web: 0.5em) !default;
 
-/// Left margin for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Left margin for title page publisher text on elements with a class of `publisher`.
 /// @type String | Map
 /// @since 1.2.0
 $title-publisher-margin-left: (epub: 0, prince: 0, web: 0) !default;
 
-/// Float for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Float for title page publisher text on elements with a class of `publisher`.
 /// @type String | Map
 /// @since 1.4.0
 $title-publisher-float: (epub: none, prince: none, web: none) !default;
 
-/// Font stack for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Font stack for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-font-family: $font-3 !default;
 
-/// Font size for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Font size for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-font-size: 0.9em !default;
 
-/// Font style for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Font style for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-font-style: normal !default;
 
-/// Font weight for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Font weight for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-font-weight: normal !default;
 
-/// Line height for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Line height for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-line-height: 1em !default;
 
-/// Letter spacing for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Letter spacing for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-letter-spacing: 1px !default;
 
-/// Word spacing for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Word spacing for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-word-spacing: 2px !default;
 
-/// Text transform for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Text transform for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-align: center !default;
 
-/// Text transform for title page publisher text on elements `<h4>` with a class of `publisher`.
+/// Text transform for title page publisher text on elements with a class of `publisher`.
 /// @type String
 $title-publisher-text-transform: none !default;
 
@@ -449,54 +449,54 @@ $title-publisher-padding-bottom: $title-title-padding-bottom !default;
 
 // Publisher city
 
-/// Right margin for title page publisher city text on elements `<h4>` with a class of `publisher`.
+/// Right margin for title page publisher city text on elements with a class of `publisher`.
 /// @type String | Map
 /// @since 1.2.0
 $title-publisher-city-margin-right: $title-publisher-margin-right !default;
 
-/// Left margin for title page publisher city text on elements `<h4>` with a class of `publisher`.
+/// Left margin for title page publisher city text on elements with a class of `publisher`.
 /// @type String | Map
 /// @since 1.2.0
 $title-publisher-city-margin-left: $title-publisher-margin-left !default;
 
-/// Float for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Float for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String | Map
 /// @since 1.4.0
 $title-publisher-city-float: (epub: none, prince: none, web: none) !default;
 
-/// Font stack for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Font stack for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-font-family: $font-3 !default;
 
-/// Font size for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Font size for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-font-size: 0.9em !default;
 
-/// Font style for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Font style for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-font-style: normal !default;
 
-/// Font weight for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Font weight for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-font-weight: normal !default;
 
-/// Line height for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Line height for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-line-height: 1em !default;
 
-/// Letter spacing for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Letter spacing for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-letter-spacing: 1px !default;
 
-/// Word spacing for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Word spacing for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-word-spacing: 2px !default;
 
-/// Alignment for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Alignment for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-align: center !default;
 
-/// Text transform for title page publisher city text on elements `<h5>` with a class of `publisher-city`.
+/// Text transform for title page publisher city text on elements with a class of `publisher-city`.
 /// @type String
 $title-publisher-city-text-transform: uppercase !default;
 

--- a/packages/buckram/tests/features/images/large-captioned/index.html
+++ b/packages/buckram/tests/features/images/large-captioned/index.html
@@ -12,7 +12,7 @@
        id="chapter-big-images-yes-captions">
     <div class="chapter-title-wrap">
       <p class="chapter-number">3</p>
-      <p class="chapter-title">Big Images – YES CAPTIONS!</p>
+      <h2 class="chapter-title">Big Images – YES CAPTIONS!</h2>
     </div>
     <div class="ugc chapter-ugc">
       <h2>BIG IMAGE – WITH CAPTIONS – ALIGNNONE</h2>

--- a/packages/buckram/tests/features/images/large-captioned/index.html
+++ b/packages/buckram/tests/features/images/large-captioned/index.html
@@ -11,8 +11,8 @@
   <div class="chapter standard"
        id="chapter-big-images-yes-captions">
     <div class="chapter-title-wrap">
-      <h3 class="chapter-number">3</h3>
-      <h2 class="chapter-title">Big Images – YES CAPTIONS!</h2>
+      <p class="chapter-number">3</p>
+      <p class="chapter-title">Big Images – YES CAPTIONS!</p>
     </div>
     <div class="ugc chapter-ugc">
       <h2>BIG IMAGE – WITH CAPTIONS – ALIGNNONE</h2>


### PR DESCRIPTION
This PR closes https://github.com/pressbooks/pressbooks/issues/2452

How to test.

Export a book with different formats and you should see the same styling as the integrations/production networks.