### PR TITLE
Fix aria-labels for nav elements

### DIFF
--- a/header.php
+++ b/header.php
@@ -88,8 +88,8 @@
 			</div>
 			<div class="header__nav">
 				<a class="header__nav-icon js-header-nav-toggle" href="#navigation"><?php _e( 'Toggle Menu', 'pressbooks-book' ); ?><span class="header__nav-icon__icon"></span></a>
-				<nav aria-labelledby="book-toc" class="js-header-nav" id="navigation">
-					<p id="book-toc" class="screen-reader-text">Book Contents Navigation</p>
+				<nav aria-labelledby="primary-nav" class="js-header-nav" id="navigation">
+					<p id="primary-nav" class="screen-reader-text">Primary Navigation</p>
 					<ul id="nav-primary-menu" class="nav--primary">
 						<?php echo \PressbooksBook\Helpers\display_menu(); ?>
 					</ul>
@@ -98,7 +98,8 @@
 		</div>
 		<?php if ( ! is_front_page() && pb_get_first_post_id() ) { ?>
 			<div class="reading-header">
-				<nav class="reading-header__inside">
+				<nav aria-labelledby="book-toc" class="reading-header__inside">
+					<p id="book-toc" class="screen-reader-text">Book Contents Navigation</p>
 					<?php if ( is_single() ) { ?>
 					<div class="reading-header__toc dropdown">
 						<div class="reading-header__toc__title"><?php _e( 'Contents', 'pressbooks-book' ); ?></div>

--- a/partials/content-cover-toc.php
+++ b/partials/content-cover-toc.php
@@ -5,7 +5,9 @@
 			<button id="show" class="button"><?php _e( 'Show All Contents', 'pressbooks-book' ); ?></button>
 			<button id="hide" class="button"><?php _e( 'Hide All Contents', 'pressbooks-book' ); ?></button>
 		</div>
-		<nav><?php include( locate_template( 'partials/content-toc.php' ) ); ?></nav>
+		<nav aria-labelledby="book-toc">
+			<p id="book-toc" class="screen-reader-text">Book Contents Navigation</p>
+			<?php include( locate_template( 'partials/content-toc.php' ) ); ?></nav>
 		<?php
 	endif;
 	/**


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks-book/issues/874. Previous PR (https://github.com/pressbooks/pressbooks-aldine/pull/282) applied the ToC label to top nav menu and didn't add labels to ToC nav on book homepage or reading interface.

To test:
1. Visit network homepage and check that top nav has primary navigation aria-label
2. Visit book homepage and make sure that top nav has 'primary navigation' screen reader text label and ToC nav has 'Book Contents Navigation' screen reader text label
3. Visit chapter inside a book and make sure top nav has 'primary navigation' screen reader text label, ToC nav has 'Book Contents Navigation' screen reader text label, and previous/next buttons have 'previous/next navigation screen reader text label'