### PR TITLE
ci: automatically commit updated POT files

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -20,18 +20,16 @@ jobs:
         tools: composer, wp-cli
     - name: Install dependencies
       run: |
-        wp package install wp-cli/i18n-command:2.2.6
-        wp package install pressbooks/pb-cli:dev-dev#800cec8
+        wp package install wp-cli/i18n-command:2.2.8
+        cd /home/runner/.wp-cli/packages/
+        composer config repositories.wp-cli '{"type": "composer","url": "https://wp-cli.org/package-index/","canonical": false}'
+        cd ./
+        wp package install pressbooks/pb-cli:2.1.0
         composer require jenssegers/blade:1.1.0
     - name: Update POT file
       run: wp pb make-pot . languages/pressbooks-book.pot --require=vendor/autoload.php --domain=pressbooks-book --slug=pressbooks-book --package-name="McLuhan" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-book/issues\"}"
-    # Remove the next four lines and uncomment the last five lines once the process has been confirmed to work as desired.
-    - uses: actions/upload-artifact@v2
+    - name: Commit updated POT file
+      uses: stefanzweifel/git-auto-commit-action@v4.1.1
       with:
-        name: pressbooks-book.pot
-        path: languages/pressbooks-book.pot
-    # - name: Commit updated POT file
-    #   uses: stefanzweifel/git-auto-commit-action@v4.1.1
-    #   with:
-    #     commit_message: 'chore(l10n): update languages/pressbooks-book.pot'
-    #     file_pattern: '*.pot'
+        commit_message: 'chore(l10n): update languages/pressbooks-book.pot'
+        file_pattern: '*.pot'


### PR DESCRIPTION
This PR updates the POT generation routine with a fix for dependency installation and enables automatic committing of generated POT files to the `dev` branch.