### PR TITLE
feat: Improve digital PDF a11y

### DIFF
--- a/assets/legacy/styles/_prince-toc.scss
+++ b/assets/legacy/styles/_prince-toc.scss
@@ -30,7 +30,6 @@
     margin-bottom: 2cm;
     margin-left: 1cm;
     text-align: left;
-    prince-bookmark-level: 1;
   }
 
   /* TOC general styling */

--- a/assets/legacy/styles/_prince-toc.scss
+++ b/assets/legacy/styles/_prince-toc.scss
@@ -30,6 +30,7 @@
     margin-bottom: 2cm;
     margin-left: 1cm;
     text-align: left;
+    prince-bookmark-level: 1;
   }
 
   /* TOC general styling */

--- a/packages/buckram/assets/styles/components/pages/_back-matter.scss
+++ b/packages/buckram/assets/styles/components/pages/_back-matter.scss
@@ -59,3 +59,9 @@ div.index {
     width: auto;
   }
 }
+
+@if $type == 'prince' {
+  .back-matter.with-subsections .back-matter-ugc h1 {
+    prince-bookmark-level: 2;
+  }
+}

--- a/packages/buckram/assets/styles/components/pages/_chapters.scss
+++ b/packages/buckram/assets/styles/components/pages/_chapters.scss
@@ -29,11 +29,11 @@
 }
 
 @if $type == 'prince' {
-  .chapter.has-subsections .chapter-ugc h1 {
+  .chapter.with-subsections .chapter-ugc h1 {
     prince-bookmark-level: 2;
   }
 
-  div.part ~ .chapter.has-subsections .chapter-ugc h1 {
+  div.part ~ .chapter.with-subsections .chapter-ugc h1 {
     prince-bookmark-level: 3;
   }
 }

--- a/packages/buckram/assets/styles/components/pages/_chapters.scss
+++ b/packages/buckram/assets/styles/components/pages/_chapters.scss
@@ -27,3 +27,13 @@
     width: auto;
   }
 }
+
+@if $type == 'prince' {
+  .chapter.has-subsections .chapter-ugc h1 {
+    prince-bookmark-level: 2;
+  }
+
+  div.part ~ .chapter.has-subsections .chapter-ugc h1 {
+    prince-bookmark-level: 3;
+  }
+}

--- a/packages/buckram/assets/styles/components/pages/_front-matter.scss
+++ b/packages/buckram/assets/styles/components/pages/_front-matter.scss
@@ -101,6 +101,12 @@ section.epigraph
   text-indent: 0;
 }
 
+@if $type == 'prince' {
+  .front-matter.with-subsections .front-matter-ugc h1 {
+    prince-bookmark-level: 2;
+  }
+}
+
 @if $type == 'epub' {
   @media amzn-mobi {
     #copyright-page {

--- a/packages/buckram/assets/styles/components/pages/_titles.scss
+++ b/packages/buckram/assets/styles/components/pages/_titles.scss
@@ -20,6 +20,9 @@
   word-spacing: $title-half-title-word-spacing;
   text-align: $title-half-title-align;
   text-transform: $title-half-title-text-transform;
+  @if $type == 'prince' {
+    prince-bookmark-level: none;
+  }
 }
 
 // Title Page
@@ -38,6 +41,9 @@
   text-transform: $title-title-text-transform;
   border-bottom: if-map-get($title-title-border-bottom-width, $type) $title-title-border-bottom-style if-map-get($title-title-border-bottom-color, $type);
   padding-bottom: if-map-get($title-title-padding-bottom, $type);
+  @if $type == 'prince' {
+    prince-bookmark-level: none;
+  }
   @if $type != 'epub' {
     line-height: if-map-get($title-title-line-height, $type);
   }

--- a/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_back-matter.scss
@@ -21,6 +21,9 @@
       font-style: $back-matter-title-font-style;
       font-weight: $back-matter-title-font-weight;
       hyphens: none;
+      @if $type == 'prince' {
+        prince-bookmark-level: 1;
+      }
       @if $type != 'epub' {
         line-height: if-map-get($back-matter-title-line-height, $type);
       }

--- a/packages/buckram/assets/styles/components/section-titles/_chapters.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_chapters.scss
@@ -136,6 +136,12 @@
       margin-bottom: if-map-get($section-subtitle-margin-bottom, $type);
     }
   }
+
+  @if $type == 'prince' {
+    div.part ~ .chapter .chapter-title {
+      prince-bookmark-level: 2;
+    }
+  }
 }
 
 .aphorism,

--- a/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
+++ b/packages/buckram/assets/styles/components/section-titles/_front-matter.scss
@@ -25,6 +25,9 @@
       letter-spacing: if-map-get($front-matter-title-letter-spacing, $type);
       word-spacing: if-map-get($front-matter-title-word-spacing, $type);
       hyphens: none;
+      @if $type == 'prince' {
+        prince-bookmark-level: 1;
+      }
       @if $type != 'epub' {
         line-height: if-map-get($front-matter-title-line-height, $type);
       }

--- a/packages/buckram/assets/styles/components/toc/_generic.scss
+++ b/packages/buckram/assets/styles/components/toc/_generic.scss
@@ -221,6 +221,10 @@
     counter-reset: part;
     page-break-before: right;
 
+    h1 {
+      prince-bookmark-level: 1;
+    }
+
     a::after {
       content: $toc-page-number-before-content target-counter(attr(href), page);
       font-family: $toc-page-number-font-family;


### PR DESCRIPTION
Fixes pressbooks/pressbooks#2300 and pressbooks/pressbooks#2485. Accompanies pressbooks/pressbooks#2532.

This PR handles the styling portion for the digital PDF accessibility improvements.

#### How to test

See pressbooks/pressbooks#2485 for a clear understanding and make sure of the following:

- Half title page and title page are not visible in digital pdf bookmarks
- Table fo contents is a level 1 bookmark
- Each front/back matter is displayed as a level 1 bookmark
- If a book has more than 1 visible part, ensure that the title of each part is displayed as a level 1 bookmark
- Display the title of each chapter within a visible part as level 2 bookmark
- Display the title of each chapter within an invisible part as a level 1 bookmark
- If the two-level ToC enabled, all H1s inside of chapters within a visible part should be displayed with the corresponding bookmark level. Level 2 when chapter is a level 1, and level 3 when chapter is a level 2.