### PR TITLE
Add Directory link to footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -64,7 +64,7 @@ if ( $contact_link ) {
 				<p class="footer__pressbooks__links__title"><a href="https://pressbooks.com"><?php printf( __( 'Powered by %s', 'pressbooks-book' ), '<span class="pressbooks">Pressbooks</span>' ); ?></a></p>
 				<ul class="footer__pressbooks__links__list">
 					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-guide-tutorials"><a href="https://pressbooks.com/support/"><?php _e( 'Guides and Tutorials', 'pressbooks-book' ); ?></a></li>
-					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-pressbooks-directory"><a href="https://pressbooks.directory"><?php _e( 'Pressbooks Directory', 'pressbooks-book' ); ?></a></li>
+					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-pressbooks-directory">|<a href="https://pressbooks.directory"><?php _e( 'Pressbooks Directory', 'pressbooks-book' ); ?></a></li>
 					<?php if ( $contact_link ) : ?>
 						<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-contact">|<a href="<?php echo $contact_link; ?>"><?php _e( 'Contact', 'pressbooks-aldine' ); ?></a></li>
 					<?php endif; ?>

--- a/footer.php
+++ b/footer.php
@@ -64,6 +64,7 @@ if ( $contact_link ) {
 				<p class="footer__pressbooks__links__title"><a href="https://pressbooks.com"><?php printf( __( 'Powered by %s', 'pressbooks-book' ), '<span class="pressbooks">Pressbooks</span>' ); ?></a></p>
 				<ul class="footer__pressbooks__links__list">
 					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-guide-tutorials"><a href="https://pressbooks.com/support/"><?php _e( 'Guides and Tutorials', 'pressbooks-book' ); ?></a></li>
+					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-pressbooks-directory"><a href="https://pressbooks.directory"><?php _e( 'Pressbooks Directory', 'pressbooks-book' ); ?></a></li>
 					<?php if ( $contact_link ) : ?>
 						<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-contact">|<a href="<?php echo $contact_link; ?>"><?php _e( 'Contact', 'pressbooks-aldine' ); ?></a></li>
 					<?php endif; ?>


### PR DESCRIPTION
Fix for https://github.com/pressbooks/ideas/issues/399

To test:
1. checkout this branch
2. navigate to the footer of a book or any chapter in a book
3. observe that a valid link to the Pressbooks Directory has been added
![Screenshot from 2021-11-29 17-59-45](https://user-images.githubusercontent.com/13485451/143972075-f45c65dc-d078-47ca-b892-830c505cb61c.png)