### PR TITLE
feature: add get parameter for filter h5p activity in h5p listing page

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -719,7 +719,7 @@ function get_h5p_activities( $per_page = 20 ) {
 			ARRAY_A
 		);
 		// phpcs:enable
-		$total = 1;
+		$total = $data ? 1 : 0;
 		$per_page = 1;
 	} else {
 		$total = $wpdb->get_var(

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -723,16 +723,16 @@ function get_h5p_activities( $per_page = 20 ) {
 		$per_page = 1;
 	} else {
 		$total = $wpdb->get_var(
-		"SELECT count(C.ID) FROM {$wpdb->prefix}h5p_contents as C
+			"SELECT count(C.ID) FROM {$wpdb->prefix}h5p_contents as C
 			LEFT JOIN {$wpdb->prefix}h5p_libraries as L on C.library_id = L.id order by C.ID"
 		);
 		$data = $wpdb->get_results(
 			$wpdb->prepare(
-		"SELECT C.ID, C.title, L.title as activity_type FROM {$wpdb->prefix}h5p_contents as C
+				"SELECT C.ID, C.title, L.title as activity_type FROM {$wpdb->prefix}h5p_contents as C
 				LEFT JOIN {$wpdb->prefix}h5p_libraries as L on C.library_id = L.id order by C.ID
 				LIMIT %d OFFSET %d;
 				", [ $per_page, $offset ]
-				), ARRAY_A
+			), ARRAY_A
 		);
 	}
 

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -703,19 +703,38 @@ function get_h5p_activities( $per_page = 20 ) {
 		$offset = $page;
 	}
 
-	$total = $wpdb->get_var(
-		"SELECT count(C.ID) FROM {$wpdb->prefix}h5p_contents as C
-					LEFT JOIN {$wpdb->prefix}h5p_libraries as L on C.library_id = L.id order by C.ID"
-	);
-
+	$h5p_id = isset( $_GET['h5p_id'] ) ? abs( intval( $_GET['h5p_id'] ) ) : null;
+	if ( ! is_null( $h5p_id ) ) {
+		// phpcs:disable
 		$data = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT C.ID, C.title, L.title as activity_type FROM {$wpdb->prefix}h5p_contents as C
-					LEFT JOIN {$wpdb->prefix}h5p_libraries as L on C.library_id = L.id order by C.ID
-					LIMIT %d OFFSET %d;
-				", [ $per_page, $offset ]
-			), ARRAY_A
+			"
+				SELECT C.ID, C.title, L.title as activity_type
+				  FROM {$wpdb->prefix}h5p_contents as C
+				  LEFT JOIN {$wpdb->prefix}h5p_libraries as L on C.library_id = L.id
+				  WHERE C.ID = %d
+				",
+				$h5p_id
+			),
+			ARRAY_A
 		);
+		// phpcs:enable
+		$total = 1;
+		$per_page = 1;
+	} else {
+		$total = $wpdb->get_var(
+		"SELECT count(C.ID) FROM {$wpdb->prefix}h5p_contents as C
+			LEFT JOIN {$wpdb->prefix}h5p_libraries as L on C.library_id = L.id order by C.ID"
+		);
+		$data = $wpdb->get_results(
+			$wpdb->prepare(
+		"SELECT C.ID, C.title, L.title as activity_type FROM {$wpdb->prefix}h5p_contents as C
+				LEFT JOIN {$wpdb->prefix}h5p_libraries as L on C.library_id = L.id order by C.ID
+				LIMIT %d OFFSET %d;
+				", [ $per_page, $offset ]
+				), ARRAY_A
+		);
+	}
 
 	$pagination = paginate_links(
 		[

--- a/page-h5p-listing.php
+++ b/page-h5p-listing.php
@@ -12,9 +12,9 @@ if ( \PressbooksBook\Helpers\is_book_public() ) :
 				<strong><?php echo $data['total'] . ' '; ?></strong>
 			<?php echo __( 'H5P activities. Only those which have been inserted into book content will be included if the book is cloned.', 'pressbooks-book' ); ?>
 			<?php
-				if ( $activities > 1 ) {
-					echo sprintf( '<button type="button" id="h5p-show-hide" class="btn btn-secondary btn-sm" show-all-text="%s" hide-all-text="%s" aria-label="%s"></button>', __( 'Expand all', 'pressbooks-book' ), __( 'Hide all', 'pressbooks-book' ), __( 'Expand all activities', 'pressbooks-book' ) );
-				}
+			if ( $activities > 1 ) {
+				echo sprintf( '<button type="button" id="h5p-show-hide" class="btn btn-secondary btn-sm" show-all-text="%s" hide-all-text="%s" aria-label="%s"></button>', __( 'Expand all', 'pressbooks-book' ), __( 'Hide all', 'pressbooks-book' ), __( 'Expand all activities', 'pressbooks-book' ) );
+			}
 			?>
 			</p>
 			<table class="table table-borderless" id="h5p-listing-table">

--- a/page-h5p-listing.php
+++ b/page-h5p-listing.php
@@ -4,13 +4,19 @@ get_header(); ?>
 if ( \PressbooksBook\Helpers\is_book_public() ) :
 	$data = \PressbooksBook\Helpers\get_h5p_activities();
 	$activities = count( $data['activities'] );
+	$filtered_by_id_exists = isset( $_GET['h5p_id'] ) && $activities === 1;
+	$filtered_does_not_exist = isset( $_GET['h5p_id'] ) && $activities === 0;
 	?>
 	<div id="post-<?php the_ID(); ?>" <?php post_class( 'h5p-listing-page' ); ?>>
 		<h1 class="page-title">
 			<?php
-			echo isset( $_GET['h5p_id'] ) ?
-				$data['activities'][0]['title'] :
-				__( 'H5P activities list', 'pressbooks-book' );
+			if ( $filtered_by_id_exists ) {
+				echo $data['activities'][0]['title'];
+			} elseif ( $filtered_does_not_exist ) {
+				echo __( 'Invalid H5P activity', 'pressbooks-book' );
+			} else {
+				echo __( 'H5P activities list', 'pressbooks-book' );
+			}
 			?>
 		</h1>
 		<?php if ( ! isset( $_GET['h5p_id'] ) ) : ?>
@@ -21,13 +27,18 @@ if ( \PressbooksBook\Helpers\is_book_public() ) :
 				<?php echo sprintf( '<button type="button" id="h5p-show-hide" class="btn btn-secondary btn-sm" show-all-text="%s" hide-all-text="%s" aria-label="%s"></button>', __( 'Expand all', 'pressbooks-book' ), __( 'Hide all', 'pressbooks-book' ), __( 'Expand all activities', 'pressbooks-book' ) ); ?>
 			</p>
 		<?php endif; ?>
+		<?php if ( $filtered_does_not_exist ) : ?>
+			<p class="h5p-count">
+				<?php echo __( 'The H5P activity does not exist in this book.', 'pressbooks-book' ); ?>
+			</p>
+		<?php endif; ?>
 		<table class="table table-borderless" id="h5p-listing-table">
 			<thead>
 			<tr>
 				<th><?php echo __( 'ID', 'pressbooks-book' ); ?></th>
 				<th><?php echo __( 'Title', 'pressbooks-book' ); ?></th>
 				<th><?php echo __( 'Activity type', 'pressbooks-book' ); ?></th>
-				<?php if ( ! isset( $_GET['h5p_id'] ) ) : ?>
+				<?php if ( ! $filtered_by_id_exists ) : ?>
 					<th><?php echo __( 'Show/Hide', 'pressbooks-book' ); ?></th>
 				<?php endif; ?>
 			</tr>
@@ -40,11 +51,11 @@ if ( \PressbooksBook\Helpers\is_book_public() ) :
 				echo sprintf( '<td>%s</td>', $activity['ID'] );
 				echo sprintf( '<td>%s</td>', $activity['title'] );
 				echo sprintf( '<td>%s</td>', $activity['activity_type'] );
-				if ( ! isset( $_GET['h5p_id'] ) ) {
+				if ( ! $filtered_by_id_exists ) {
 					echo sprintf( '<td><button h5p-id="%s" type="button" show-activity-text="%s" hide-activity-text="%s" aria-label="%s" class="btn btn-secondary btn-sm h5p-row-item"></button></td>', $activity['ID'], __( 'Show activity', 'pressbooks-book' ), __( 'Hide activity', 'pressbooks-book' ), __( 'View h5p activity', 'pressbooks-book' ) );
 				}
 				echo '</tr>';
-				echo isset( $_GET['h5p_id'] ) ?
+				echo $filtered_by_id_exists ?
 					sprintf( '<tr><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) ) :
 					sprintf( '<tr class="h5p-activity-container"><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) );
 			}

--- a/page-h5p-listing.php
+++ b/page-h5p-listing.php
@@ -6,45 +6,51 @@ if ( \PressbooksBook\Helpers\is_book_public() ) :
 	$activities = count( $data['activities'] );
 	?>
 	<div id="post-<?php the_ID(); ?>" <?php post_class( 'h5p-listing-page' ); ?>>
-			<h1 class="page-title"><?php echo __( 'H5P activities list', 'pressbooks-book' ); ?></h1>
+		<h1 class="page-title">
+			<?php
+			echo isset( $_GET['h5p_id'] ) ?
+				$data['activities'][0]['title'] :
+				__( 'H5P activities list', 'pressbooks-book' );
+			?>
+		</h1>
+		<?php if ( ! isset( $_GET['h5p_id'] ) ) : ?>
 			<p class="h5p-count">
 				<?php echo __( 'This book includes ', 'pressbooks-book' ); ?>
 				<strong><?php echo $data['total'] . ' '; ?></strong>
-			<?php echo __( 'H5P activities. Only those which have been inserted into book content will be included if the book is cloned.', 'pressbooks-book' ); ?>
+				<?php echo __( 'H5P activities. Only those which have been inserted into book content will be included if the book is cloned.', 'pressbooks-book' ); ?>
+				<?php echo sprintf( '<button type="button" id="h5p-show-hide" class="btn btn-secondary btn-sm" show-all-text="%s" hide-all-text="%s" aria-label="%s"></button>', __( 'Expand all', 'pressbooks-book' ), __( 'Hide all', 'pressbooks-book' ), __( 'Expand all activities', 'pressbooks-book' ) ); ?>
+			</p>
+		<?php endif; ?>
+		<table class="table table-borderless" id="h5p-listing-table">
+			<thead>
+			<tr>
+				<th><?php echo __( 'ID', 'pressbooks-book' ); ?></th>
+				<th><?php echo __( 'Title', 'pressbooks-book' ); ?></th>
+				<th><?php echo __( 'Activity type', 'pressbooks-book' ); ?></th>
+				<?php if ( ! isset( $_GET['h5p_id'] ) ) : ?>
+					<th><?php echo __( 'Show/Hide', 'pressbooks-book' ); ?></th>
+				<?php endif; ?>
+			</tr>
+			</thead>
+			<tbody>
 			<?php
-			if ( $activities > 1 ) {
-				echo sprintf( '<button type="button" id="h5p-show-hide" class="btn btn-secondary btn-sm" show-all-text="%s" hide-all-text="%s" aria-label="%s"></button>', __( 'Expand all', 'pressbooks-book' ), __( 'Hide all', 'pressbooks-book' ), __( 'Expand all activities', 'pressbooks-book' ) );
+			foreach ( $data['activities'] as $activity ) {
+				$short_code = sprintf( '[h5p id="%s"]', $activity['ID'] );
+				echo '<tr>';
+				echo sprintf( '<td>%s</td>', $activity['ID'] );
+				echo sprintf( '<td>%s</td>', $activity['title'] );
+				echo sprintf( '<td>%s</td>', $activity['activity_type'] );
+				if ( ! isset( $_GET['h5p_id'] ) ) {
+					echo sprintf( '<td><button h5p-id="%s" type="button" show-activity-text="%s" hide-activity-text="%s" aria-label="%s" class="btn btn-secondary btn-sm h5p-row-item"></button></td>', $activity['ID'], __( 'Show activity', 'pressbooks-book' ), __( 'Hide activity', 'pressbooks-book' ), __( 'View h5p activity', 'pressbooks-book' ) );
+				}
+				echo '</tr>';
+				echo isset( $_GET['h5p_id'] ) ?
+					sprintf( '<tr><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) ) :
+					sprintf( '<tr class="h5p-activity-container"><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) );
 			}
 			?>
-			</p>
-			<table class="table table-borderless" id="h5p-listing-table">
-				<thead>
-				<tr>
-					<th><?php echo __( 'ID', 'pressbooks-book' ); ?></th>
-					<th><?php echo __( 'Title', 'pressbooks-book' ); ?></th>
-					<th><?php echo __( 'Activity type', 'pressbooks-book' ); ?></th>
-					<th><?php echo __( 'Show/Hide', 'pressbooks-book' ); ?></th>
-				</tr>
-				</thead>
-				<tbody>
-				<?php
-				foreach ( $data['activities'] as $activity ) {
-					$short_code = sprintf( '[h5p id="%s"]', $activity['ID'] );
-					echo '<tr>';
-					echo sprintf( '<td>%s</td>', $activity['ID'] );
-					echo sprintf( '<td>%s</td>', $activity['title'] );
-					echo sprintf( '<td>%s</td>', $activity['activity_type'] );
-					echo $activities === 1 ?
-						'<td></td>' :
-						sprintf( '<td><button h5p-id="%s" type="button" show-activity-text="%s" hide-activity-text="%s" aria-label="%s" class="btn btn-secondary btn-sm h5p-row-item"></button></td>', $activity['ID'], __( 'Show activity', 'pressbooks-book' ), __( 'Hide activity', 'pressbooks-book' ), __( 'View h5p activity', 'pressbooks-book' ) );
-					echo '</tr>';
-					echo $activities === 1 ?
-						sprintf( '<tr><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) ) :
-						sprintf( '<tr class="h5p-activity-container"><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) );
-				}
-				?>
-				</tbody>
-			</table>
+			</tbody>
+		</table>
 		<div class="h5p-pagination">
 			<?php echo $data['pagination']; ?>
 		</div>

--- a/page-h5p-listing.php
+++ b/page-h5p-listing.php
@@ -3,6 +3,7 @@ get_header(); ?>
 <?php
 if ( \PressbooksBook\Helpers\is_book_public() ) :
 	$data = \PressbooksBook\Helpers\get_h5p_activities();
+	$activities = count( $data['activities'] );
 	?>
 	<div id="post-<?php the_ID(); ?>" <?php post_class( 'h5p-listing-page' ); ?>>
 			<h1 class="page-title"><?php echo __( 'H5P activities list', 'pressbooks-book' ); ?></h1>
@@ -10,7 +11,11 @@ if ( \PressbooksBook\Helpers\is_book_public() ) :
 				<?php echo __( 'This book includes ', 'pressbooks-book' ); ?>
 				<strong><?php echo $data['total'] . ' '; ?></strong>
 			<?php echo __( 'H5P activities. Only those which have been inserted into book content will be included if the book is cloned.', 'pressbooks-book' ); ?>
-			<?php echo sprintf( '<button type="button" id="h5p-show-hide" class="btn btn-secondary btn-sm" show-all-text="%s" hide-all-text="%s" aria-label="%s"></button>', __( 'Expand all', 'pressbooks-book' ), __( 'Hide all', 'pressbooks-book' ), __( 'Expand all activities', 'pressbooks-book' ) ); ?>
+			<?php
+				if ( $activities > 1 ) {
+					echo sprintf( '<button type="button" id="h5p-show-hide" class="btn btn-secondary btn-sm" show-all-text="%s" hide-all-text="%s" aria-label="%s"></button>', __( 'Expand all', 'pressbooks-book' ), __( 'Hide all', 'pressbooks-book' ), __( 'Expand all activities', 'pressbooks-book' ) );
+				}
+			?>
 			</p>
 			<table class="table table-borderless" id="h5p-listing-table">
 				<thead>
@@ -23,16 +28,19 @@ if ( \PressbooksBook\Helpers\is_book_public() ) :
 				</thead>
 				<tbody>
 				<?php
-
 				foreach ( $data['activities'] as $activity ) {
 					$short_code = sprintf( '[h5p id="%s"]', $activity['ID'] );
 					echo '<tr>';
 					echo sprintf( '<td>%s</td>', $activity['ID'] );
 					echo sprintf( '<td>%s</td>', $activity['title'] );
 					echo sprintf( '<td>%s</td>', $activity['activity_type'] );
-					echo sprintf( '<td><button h5p-id="%s" type="button" show-activity-text="%s" hide-activity-text="%s" aria-label="%s" class="btn btn-secondary btn-sm h5p-row-item"></button></td>', $activity['ID'], __( 'Show activity', 'pressbooks-book' ), __( 'Hide activity', 'pressbooks-book' ), __( 'View h5p activity', 'pressbooks-book' ) );
+					echo $activities === 1 ?
+						'<td></td>' :
+						sprintf( '<td><button h5p-id="%s" type="button" show-activity-text="%s" hide-activity-text="%s" aria-label="%s" class="btn btn-secondary btn-sm h5p-row-item"></button></td>', $activity['ID'], __( 'Show activity', 'pressbooks-book' ), __( 'Hide activity', 'pressbooks-book' ), __( 'View h5p activity', 'pressbooks-book' ) );
 					echo '</tr>';
-					echo sprintf( '<tr class="h5p-activity-container"><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) );
+					echo $activities === 1 ?
+						sprintf( '<tr><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) ) :
+						sprintf( '<tr class="h5p-activity-container"><td colspan="4">%s</td></tr>', do_shortcode( $short_code ) );
 				}
 				?>
 				</tbody>

--- a/page-h5p-listing.php
+++ b/page-h5p-listing.php
@@ -29,7 +29,7 @@ if ( \PressbooksBook\Helpers\is_book_public() ) :
 		<?php endif; ?>
 		<?php if ( $filtered_does_not_exist ) : ?>
 			<p class="h5p-count">
-				<?php echo __( 'The H5P activity does not exist in this book.', 'pressbooks-book' ); ?>
+				<?php echo __( 'The requested H5P activity does not exist in this book.', 'pressbooks-book' ); ?>
 			</p>
 		<?php endif; ?>
 		<table class="table table-borderless" id="h5p-listing-table">

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -228,5 +228,10 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertTrue( str_contains( $data['pagination'], 'page=2"' ) );
 		$this->assertTrue( str_contains( $data['pagination'], 'page=3"' ) );
 
+		$_GET['h5p_id'] = $data['activities'][0]['ID'];
+		$data = \PressbooksBook\Helpers\get_h5p_activities();
+		$this->assertEquals( '1', $data['total'] );
+		$this->assertEquals( 1, count( $data['activities'] ) );
+		$this->assertEquals( $_GET['h5p_id'], $data['activities'][0]['ID'] );
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-lti-provider-1p3/issues/163

This change adds the option to filter by a specific h5p activity in the h5p activities listing page by passing the h5p_id get parameter. It also adds id attributes to the activities in order to be able to anchor to a specific activity id when needed.

This PR could be tested and merged independently from: https://github.com/pressbooks/pressbooks-lti-provider-1p3/pull/192

### Testing
Add the h5p_id get parameter with some valid h5p activity id in the h5p listing page for a book. It must display 1 single activity.