### PR TITLE
fix: use math.div instead of `/`

### DIFF
--- a/assets/book/typography/styles/_CardoFont.scss
+++ b/assets/book/typography/styles/_CardoFont.scss
@@ -3,6 +3,8 @@
 //CARDO: A CONSERVATIVE SERIF
 //SERIF
 
+@use "sass:math";
+
 @font-face {
   font-family: 'Cardo';
   font-weight: bold;
@@ -30,5 +32,5 @@
 // @param {Number} $line-height The desired line-height
 // @return {Number} An adjusted line height based on an esoteric calculation.
 @function fix-descender($line-height) {
-  @return ceil(($line-height * (1645 + 640) / 2048) * 40) / 40;
+  @return ceil(math.div($line-height * (1645 + 640), 2048) * 40) * 0.025;
 }

--- a/assets/src/styles/components/_toc.scss
+++ b/assets/src/styles/components/_toc.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $lightest: #fcfcfc;
 $lighter: #fafafa;
 $light: #eee;
@@ -26,7 +28,7 @@ $light: #eee;
 
 .toc button {
   background: transparent;
-  border: solid (2 / 16) * 1rem transparent;
+  border: solid math.div(2, 16) * 1rem transparent;
   border-radius: 0;
   height: 2.25rem;
   padding: 0;

--- a/assets/styles/components/_elements.scss
+++ b/assets/styles/components/_elements.scss
@@ -1,5 +1,7 @@
 // Elements
 
+@use "sass:math";
+
 $body-font-family: $font-1 !default;
 $body-font-size: (
   epub: small,
@@ -8,12 +10,12 @@ $body-font-size: (
 ) !default;
 $body-font-style: normal !default;
 $body-font-weight: normal !default;
-$body-line-height: (14 / 9) * 1em !default;
+$body-line-height: math.div(14, 9) * 1em !default;
 
-$hx-margin-top: (30 / 14) * 1em !default;
-$hx-margin-bottom: (20 / 14) * 1em !default;
+$hx-margin-top: math.div(30, 14) * 1em !default;
+$hx-margin-bottom: math.div(20, 14) * 1em !default;
 $hx-padding-bottom: 0 !default;
-$hx-line-height: (18 / 15) * 1em !default;
+$hx-line-height: math.div(18, 15) * 1em !default;
 $hx-border-bottom-style: none !default;
 $hx-border-bottom-width: 0 !default;
 $hx-border-bottom-color: initial !default;
@@ -131,7 +133,7 @@ $blockquote-font-family: $font-1 !default;
 $blockquote-font-size: 1em !default;
 $blockquote-font-style: normal !default;
 $blockquote-font-weight: normal !default;
-$blockquote-line-height: (14 / 9) * 1em !default;
+$blockquote-line-height: math.div(14, 9) * 1em !default;
 $blockquote-margin-top: 1em !default;
 $blockquote-margin-right: 1em !default;
 $blockquote-margin-bottom: 1em !default;
@@ -156,12 +158,12 @@ $blockquote-border-left-style: none !default;
 $blockquote-border-left-color: initial !default;
 
 //LISTS
-$ol-margin-top: (20 / 14) * 1em !default;
-$ol-margin-bottom: (20 / 14) * 1em !default;
+$ol-margin-top: math.div(20, 14) * 1em !default;
+$ol-margin-bottom: math.div(20, 14) * 1em !default;
 $ol-margin-left: 0 !default;
 $ol-padding-left: 2em !default;
-$ul-margin-top: (20 / 14) * 1em !default;
-$ul-margin-bottom: (20 / 14) * 1em !default;
+$ul-margin-top: math.div(20, 14) * 1em !default;
+$ul-margin-bottom: math.div(20, 14) * 1em !default;
 $ul-margin-left: 0 !default;
 $ul-padding-left: 2em !default;
 $li-li-margin-top: 0 !default;

--- a/assets/styles/components/_media.scss
+++ b/assets/styles/components/_media.scss
@@ -1,7 +1,9 @@
 // Media
+@use "sass:math";
+
 $image-caption-padding-bottom: 0.5em !default;
 $image-caption-font-family: $font-1 !default;
-$image-caption-font-size: (8 / 9) * 1em !default;
+$image-caption-font-size: math.div(8, 9) * 1em !default;
 $image-caption-font-style: italic !default;
 $image-caption-font-weight: normal !default;
 $image-caption-line-height: (
@@ -13,7 +15,7 @@ $image-caption-text-align: left !default;
 $image-caption-text-transform: none !default;
 $image-wrapper-margin-top: 0.5em !default;
 $floated-image-wrapper-margin-top: $image-wrapper-margin-top !default;
-$image-wrapper-margin-bottom: (40 / 9) * 1em !default;
+$image-wrapper-margin-bottom: math.div(40, 9) * 1em !default;
 $floated-image-wrapper-margin-bottom: 0.5em !default;
 $image-alignleft-margin-right: 1em !default;
 $image-alignright-margin-left: 1em !default;

--- a/assets/styles/components/_pages.scss
+++ b/assets/styles/components/_pages.scss
@@ -1,6 +1,8 @@
 // Pages
 
 // HALF TITLE PAGE
+@use "sass:math";
+
 $title-half-title-display:(
   epub: none,
   prince: initial,
@@ -32,8 +34,8 @@ $title-title-margin-left: 0 !default;
 $title-title-font-family: $font-2 !default;
 $title-title-font-size: (
   epub: x-large,
-  prince: (24 / 9) * 1em,
-  web: (24 / 9) * 1em
+  prince: math.div(24, 9) * 1em,
+  web: math.div(24, 9) * 1em
 ) !default;
 $title-title-font-style: normal !default;
 $title-title-font-weight: normal !default;
@@ -49,8 +51,8 @@ $title-subtitle-margin-left: 0 !default;
 $title-subtitle-font-family: $font-3 !default;
 $title-subtitle-font-size: (
   epub: large,
-  prince: (15 / 9) * 1em,
-  web: (15 / 9) * 1em
+  prince: math.div(15, 9) * 1em,
+  web: math.div(15, 9) * 1em
 ) !default;
 $title-subtitle-font-style: italic !default;
 $title-subtitle-font-weight: normal !default;
@@ -70,8 +72,8 @@ $title-author-margin-left: 0 !default;
 $title-author-font-family: $font-2 !default;
 $title-author-font-size: (
   epub: large,
-  prince: (15 / 9) * 1em,
-  web: (15 / 9) * 1em
+  prince: math.div(15, 9) * 1em,
+  web: math.div(15, 9) * 1em
 ) !default;
 $title-author-font-style: italic !default;
 $title-author-font-weight: normal !default;
@@ -125,13 +127,13 @@ $copyright-margin-bottom: 1em !default;
 $copyright-font-family: $font-1 !default;
 $copyright-font-size: (
   epub: small,
-  prince: (8 / 9) * 1em,
-  web: (8 / 9) * 1em
+  prince: math.div(8, 9) * 1em,
+  web: math.div(8, 9) * 1em
 ) !default;
 $copyright-font-style: normal !default;
 $copyright-font-weight: normal !default;
 $copyright-hyphens: none !default;
-$copyright-line-height: (14 / 9) * 1em;
+$copyright-line-height: math.div(14, 9) * 1em;
 $copyright-align: left !default;
 $copyright-indent: 0 !default;
 

--- a/assets/styles/components/_section-titles.scss
+++ b/assets/styles/components/_section-titles.scss
@@ -1,5 +1,7 @@
 // Section Titles
 
+@use "sass:math";
+
 $section-title-block-margin-top: (
   epub: 3em,
   prince: 3cm,
@@ -22,7 +24,7 @@ $section-title-block-margin-right: (
 ) !default;
 
 $section-header-margin-top: 0 !default;
-$section-header-margin-bottom: (50 / 20) * 1em !default;
+$section-header-margin-bottom: 2.5em !default;
 $section-header-margin-left: $section-title-block-margin-left !default;
 $section-header-margin-right: $section-title-block-margin-right !default;
 
@@ -52,8 +54,8 @@ $section-title-author-spacing: $section-title-margin-bottom !default;
 $section-title-font-family: $font-2 !default;
 $section-title-font-size: (
   epub: x-large,
-  prince: (24 / 9) * 1em,
-  web: (24 / 9) * 1em
+  prince: math.div(24, 9) * 1em,
+  web: math.div(24, 9) * 1em
 ) !default;
 $section-title-font-style: normal !default;
 $section-title-font-weight: normal !default;
@@ -87,8 +89,8 @@ $section-subtitle-author-spacing: (
 $section-subtitle-font-family: $font-2 !default;
 $section-subtitle-font-size: (
   epub: large,
-  prince: (15 / 9) * 1em,
-  web: (15 / 9) * 1em
+  prince: math.div(15, 9) * 1em,
+  web: math.div(15, 9) * 1em
 ) !default;
 $section-subtitle-font-style: italic !default;
 $section-subtitle-font-weight: normal !default;
@@ -343,7 +345,7 @@ $chapter-number-border-bottom-color: $section-title-border-bottom-color !default
 $chapter-number-font-family: $font-3 !default;
 $chapter-number-font-size: (
   epub: large,
-  prince: (24 / 9) * 1em,
+  prince: math.div(24, 9) * 1em,
   web: 1em
 ) !default;
 $chapter-number-font-style: normal !default;

--- a/assets/styles/components/_specials.scss
+++ b/assets/styles/components/_specials.scss
@@ -1,6 +1,8 @@
 // Special Elements
 
 // Columns
+@use "sass:math";
+
 $column-margin-top: 1em !default;
 $column-margin-bottom: 1em !default;
 $column-line-height: 1.2em !default;
@@ -26,11 +28,11 @@ $footnote-block-margin-top: 2.5em !default;
 $footnote-block-border-top: 0 !default;
 $footnote-padding-top: 1em !default;
 $footnote-padding-left: 0 !default;
-$footnote-font-size: (8 / 9) * 1rem !default;
+$footnote-font-size: math.div(8, 9) * 1rem !default;
 $footnote-font-style: normal !default;
 $footnote-font-family: $font-1 !default;
 $footnote-font-weight: normal !default;
-$footnote-line-height: (14 / 9) * 1em !default;
+$footnote-line-height: math.div(14, 9) * 1em !default;
 $footnote-indent: 0 !default;
 $footnote-blockquote-margin-top: 0.5em !default;
 $footnote-blockquote-margin-bottom: 0.5em !default;
@@ -112,8 +114,8 @@ $sidebar-align: left !default;
 
 // Separators
 $hr-width: 100% !default;
-$hr-margin-top: (20 / 9) * 1em !default;
-$hr-margin-bottom: (20 / 9) * 1em !default;
+$hr-margin-top: math.div(20, 9) * 1em !default;
+$hr-margin-bottom: math.div(20, 9) * 1em !default;
 $hr-border-style: solid !default;
 $hr-border-width: 1px !default;
 $hr-border-color: if-map-get($color-1, $type) !default;
@@ -136,7 +138,7 @@ $textbox-font-family: $font-1 !default;
 $textbox-font-size: (epub: 0.8125em, prince: 9pt, web: 1em) !default;
 $textbox-font-style: normal !default;
 $textbox-font-weight: normal !default;
-$textbox-line-height: (14 / 9) !default;
+$textbox-line-height: math.div(14, 9) !default;
 $textbox-text-align: left !default;
 $textbox-word-spacing: (
   epub: normal,
@@ -202,10 +204,10 @@ $textbox-sidebar-max-width: 25% !default;
 $edu-textbox-border-radius: 0 !default;
 $edu-textbox-border-style: none !default;
 $edu-textbox-border-width: 0 !default;
-$edu-textbox-padding-top: (16 / 9) * 1em !default;
-$edu-textbox-padding-right: (16 / 9) * 1em !default;
-$edu-textbox-padding-bottom: (16 / 9) * 1em !default;
-$edu-textbox-padding-left: (16 / 9) * 1em !default;
+$edu-textbox-padding-top: math.div(16, 9) * 1em !default;
+$edu-textbox-padding-right: math.div(16, 9) * 1em !default;
+$edu-textbox-padding-bottom: math.div(16, 9) * 1em !default;
+$edu-textbox-padding-left: math.div(16, 9) * 1em !default;
 $edu-textbox-margin-bottom: 1.35em !default;
 $edu-textbox-margin-left: (
   epub: 0,

--- a/assets/styles/epub/_fonts.scss
+++ b/assets/styles/epub/_fonts.scss
@@ -16,14 +16,14 @@ $shapeshifter-font-2-is-serif: true !default;
   $font-1: $shapeshifter-font-1, if($shapeshifter-font-1-is-serif, $serif-epub, $sans-serif-epub);
 } @else {
   $font-1: 'Lora', $serif-epub;
-  @import 'LoraFont';
+//  @import 'LoraFont';
 }
 
 @if variable-exists(shapeshifter-font-2) {
   $font-2: $shapeshifter-font-2, if($shapeshifter-font-2-is-serif, $serif-epub, $sans-serif-epub);
 } @else {
   $font-2: 'Cormorant Garamond', $serif-epub;
-  @import 'CormorantGaramondFont';
+//  @import 'CormorantGaramondFont';
 }
 
 $font-3: $font-2;

--- a/packages/aetna/assets/styles/common/_functions.scss
+++ b/packages/aetna/assets/styles/common/_functions.scss
@@ -1,7 +1,9 @@
+@use "sass:math";
+
 @function rem($pixels, $context: $base-font-size) {
-  @return #{$pixels / $context}rem;
+  @return #{math.div($pixels, $context)}rem;
 }
 
 @function percent($target, $context) {
-  @return ($target / $context) * 100%;
+  @return math.div($target, $context) * 100%;
 }

--- a/packages/aetna/assets/styles/common/_variables.scss
+++ b/packages/aetna/assets/styles/common/_variables.scss
@@ -79,7 +79,7 @@ $h4-font-size: 1.875rem !default;
 $h5-font-size: 1.5rem !default;
 $h6-font-size: 1.25rem !default;
 
-$headings-margin-bottom: ($spacer / 2) !default;
+$headings-margin-bottom: ($spacer * 0.5) !default;
 $headings-font-family: $font-family-sans-serif !default;
 $headings-font-weight: 700 !default;
 $headings-line-height: $line-height-base !default;

--- a/packages/aetna/assets/styles/layouts/_footer.scss
+++ b/packages/aetna/assets/styles/layouts/_footer.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .footer {
   --brand: var(--footer-color);
   --primary-dark: var(--footer-color);
@@ -182,7 +184,7 @@
     list-style: none;
     text-align: center;
     font-weight: 600;
-    line-height: (36/16);
+    line-height: math.div(36, 16);
   }
 
   &__block {

--- a/packages/aetna/assets/styles/layouts/_header.scss
+++ b/packages/aetna/assets/styles/layouts/_header.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .header {
   font-family: $font-family-sans-serif;
   padding: 3.5rem 1rem 1.5rem;
@@ -122,7 +124,7 @@
       display: none;
       font-family: $font-family-sans-serif;
       font-size: rem(24);
-      line-height: (80/24);
+      line-height: math.div(80, 24);
       color: var(--header-color);
       letter-spacing: 0;
     }

--- a/packages/buckram/assets/styles/components/specials/_textboxes.scss
+++ b/packages/buckram/assets/styles/components/specials/_textboxes.scss
@@ -6,6 +6,8 @@
 //                                   Textboxes                                //
 //============================================================================//
 
+@use "sass:math";
+
 @import '../utilities';
 
 // Legacy Educational Textboxes
@@ -26,17 +28,17 @@
 
   h3 {
     padding:
-      if-map-get($edu-textbox-padding-top, $type) * (1 / $edu-header-font-size-multiplier)
-      if-map-get($edu-textbox-padding-right, $type) * (1 / $edu-header-font-size-multiplier)
-      if-map-get($edu-textbox-padding-bottom, $type) * (1 / $edu-header-font-size-multiplier)
-      if-map-get($edu-textbox-padding-left, $type) * (1 / $edu-header-font-size-multiplier);
+      if-map-get($edu-textbox-padding-top, $type) * math.div(1, $edu-header-font-size-multiplier)
+      if-map-get($edu-textbox-padding-right, $type) * math.div(1, $edu-header-font-size-multiplier)
+      if-map-get($edu-textbox-padding-bottom, $type) * math.div(1, $edu-header-font-size-multiplier)
+      if-map-get($edu-textbox-padding-left, $type) * math.div(1, $edu-header-font-size-multiplier);
     margin:
-      -1 * if-map-get($edu-textbox-padding-top, $type) * (1 / $edu-header-font-size-multiplier)
-      -1 * if-map-get($edu-textbox-padding-top, $type) * (1 / $edu-header-font-size-multiplier)
-      if-map-get($edu-textbox-padding-top, $type) * (1 / $edu-header-font-size-multiplier)
-      -1 * if-map-get($edu-textbox-padding-top, $type) * (1 / $edu-header-font-size-multiplier);
-    border-top-right-radius: if-map-get($edu-textbox-border-radius, $type) * (1 / $edu-header-font-size-multiplier) - if-map-get($edu-textbox-border-width, $type);
-    border-top-left-radius: if-map-get($edu-textbox-border-radius, $type) * (1 / $edu-header-font-size-multiplier) - if-map-get($edu-textbox-border-width, $type);
+      -1 * if-map-get($edu-textbox-padding-top, $type) * math.div(1, $edu-header-font-size-multiplier)
+      -1 * if-map-get($edu-textbox-padding-top, $type) * math.div(1, $edu-header-font-size-multiplier)
+      if-map-get($edu-textbox-padding-top, $type) * math.div(1, $edu-header-font-size-multiplier)
+      -1 * if-map-get($edu-textbox-padding-top, $type) * math.div(1, $edu-header-font-size-multiplier);
+    border-top-right-radius: if-map-get($edu-textbox-border-radius, $type) * math.div(1, $edu-header-font-size-multiplier) - if-map-get($edu-textbox-border-width, $type);
+    border-top-left-radius: if-map-get($edu-textbox-border-radius, $type) * math.div(1, $edu-header-font-size-multiplier) - if-map-get($edu-textbox-border-width, $type);
     font-size: $edu-header-font-size-multiplier * if-map-get($textbox-font-size, $type);
     font-style: $edu-header-font-style;
     font-weight: $edu-header-font-weight;


### PR DESCRIPTION
This PR fixes deprecation warnings for the use of the / division operator. Changes were made automatically using this Sass migrator: https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration