### PR TITLE
feature: Display institution information on book homepage

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -442,7 +442,7 @@ function get_metakeys(): array {
 		'pb_book_license' => __( 'License', 'pressbooks-book' ),
 		'pb_primary_subject' => __( 'Primary Subject', 'pressbooks-book' ),
 		'pb_additional_subjects' => __( 'Additional Subject(s)', 'pressbooks-book' ),
-		'pb_institutions' => __( 'Institution(s)', 'pressbooks-book' ),
+		'pb_institutions' => _n_noop( 'Institution', 'Institutions', 'pressbooks-book' ),
 		'pb_publisher' => __( 'Publisher', 'pressbooks-book' ),
 		'pb_publication_date' => __( 'Publication Date', 'pressbooks-book' ),
 		'pb_book_doi' => __( 'Digital Object Identifier (DOI)', 'pressbooks-book' ),
@@ -606,12 +606,14 @@ function comments_template( $comment, $args, $depth ) {
  *
  * @since 2.3.0
  *
- * @param string $var
+ * @param string|array $value
  *
  * @return int
  */
-function count_authors( $var ) {
-	return count( \Pressbooks\Utility\oxford_comma_explode( $var ) );
+function count_items( $value ): int {
+	$countable = is_countable( $value ) ? $value : \Pressbooks\Utility\oxford_comma_explode( $value );
+
+	return count( $countable );
 }
 
 /**

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -431,7 +431,7 @@ function get_original_section( $needle, $haystack ) {
  *
  * @return array
  */
-function get_metakeys() {
+function get_metakeys(): array {
 	return [
 		'pb_authors' => _n_noop( 'Author', 'Authors', 'pressbooks-book' ),
 		'pb_editors' => _n_noop( 'Editor', 'Editors', 'pressbooks-book' ),
@@ -442,6 +442,7 @@ function get_metakeys() {
 		'pb_book_license' => __( 'License', 'pressbooks-book' ),
 		'pb_primary_subject' => __( 'Primary Subject', 'pressbooks-book' ),
 		'pb_additional_subjects' => __( 'Additional Subject(s)', 'pressbooks-book' ),
+		'pb_institutions' => __( 'Institution(s)', 'pressbooks-book' ),
 		'pb_publisher' => __( 'Publisher', 'pressbooks-book' ),
 		'pb_publication_date' => __( 'Publication Date', 'pressbooks-book' ),
 		'pb_book_doi' => __( 'Digital Object Identifier (DOI)', 'pressbooks-book' ),

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -14,7 +14,7 @@ use function \Pressbooks\Image\attachment_id_from_url;
 			<p class="book-header__subtitle"><span class="screen-reader-text"><?php _e( 'Subtitle', 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_subtitle']; ?></p>
 		<?php endif; ?>
 		<?php if ( ! empty( $book_information['pb_authors'] ) ) { ?>
-			<p class="book-header__author"><span class="screen-reader-text"><?php echo translate_nooped_plural( _n_noop( 'Author', 'Authors', 'pressbooks-book' ), \PressbooksBook\Helpers\count_authors( $book_information['pb_authors'] ), 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_authors']; ?></p>
+			<p class="book-header__author"><span class="screen-reader-text"><?php echo translate_nooped_plural( _n_noop( 'Author', 'Authors', 'pressbooks-book' ), \PressbooksBook\Helpers\count_items( $book_information['pb_authors'] ), 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_authors']; ?></p>
 		<?php } ?>
 		<div class="book-header__cover">
 			<?php if ( ! empty( $book_information['pb_cover_image'] ) ) { ?>

--- a/partials/content-cover-book-info.php
+++ b/partials/content-cover-book-info.php
@@ -49,7 +49,7 @@
 </div>
 		<div class="block-info__inner__content">
 			<div class="block-info__subsection block-info__lead-author">
-				<h3 class="block__subtitle"><?php echo _n( 'Author', 'Authors', \PressbooksBook\Helpers\count_authors( $book_information['pb_authors'] ), 'pressbooks-book' ); ?></h3>
+				<h3 class="block__subtitle"><?php echo _n( 'Author', 'Authors', \PressbooksBook\Helpers\count_items( $book_information['pb_authors'] ), 'pressbooks-book' ); ?></h3>
 				<?php if ( ! empty( $book_information['pb_authors'] ) ) { ?>
 					<div class="block-info__authors">
 						<?php // TODO add author photo ?>

--- a/partials/content-cover-metadata.php
+++ b/partials/content-cover-metadata.php
@@ -14,7 +14,7 @@
 					if ( isset( $book_information[ $key ] ) && ! empty( $book_information[ $key ] ) ) {
 						?>
 						<div class="block-meta__subsection meta--<?php echo $key; ?>">
-							<dt class="block__subtitle block-meta__subtitle"><?php echo is_array( $val ) ? translate_nooped_plural( $val, \PressbooksBook\Helpers\count_authors( $book_information[ $key ] ), 'pressbooks-book' ) : $val; ?></dt>
+							<dt class="block__subtitle block-meta__subtitle"><?php echo is_array( $val ) ? translate_nooped_plural( $val, \PressbooksBook\Helpers\count_items( $book_information[ $key ] ), 'pressbooks-book' ) : $val; ?></dt>
 							<dd class="">
 							<?php
 							if ( 'pb_publication_date' === $key ) {

--- a/partials/content-cover-metadata.php
+++ b/partials/content-cover-metadata.php
@@ -18,7 +18,7 @@
 							<dd class="">
 							<?php
 							if ( 'pb_publication_date' === $key ) {
-									$book_information[ $key ] = date_i18n( 'F j, Y', (int) $book_information[ $key ] );
+								$book_information[ $key ] = date_i18n( 'F j, Y', (int) $book_information[ $key ] );
 							} elseif ( 'pb_hashtag' === $key ) {
 								$hashtag = $book_information[ $key ];
 								$book_information[ $key ] = "<a href='https://twitter.com/search?q=%23$hashtag'>#$hashtag</a>";
@@ -33,6 +33,8 @@
 									$output[] = \Pressbooks\Metadata\get_subject_from_thema( $code );
 								}
 								$book_information[ $key ] = implode( ', ', $output );
+							} elseif ( 'pb_institutions' === $key ) {
+								$book_information[ $key ] = implode( ', ', $book_information[ $key ] );
 							} elseif ( 'pb_book_doi' === $key ) {
 								/**
 								 * Filter the DOI resolver service URL (default: https://dx.doi.org).

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -5,7 +5,7 @@
  * @package Pressbooks_Book
  */
 
-use function \PressbooksBook\Helpers\count_authors;
+use function \PressbooksBook\Helpers\count_items;
 use function \PressbooksBook\Helpers\display_menu;
 use function \PressbooksBook\Helpers\get_book_authors;
 use function \PressbooksBook\Helpers\get_metakeys;
@@ -171,15 +171,18 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertTrue( $result );
 	}
 
-	function test_count_authors() {
-		$result = count_authors( 'Author One, Author Two, and Author Three' );
+	function test_count_items() {
+		$result = count_items( 'Author One, Author Two, and Author Three' );
 		$this->assertEquals( 3, $result );
-		$result = count_authors( 'Author One and Author Two' );
+		$result = count_items( 'Author One and Author Two' );
 		$this->assertEquals( 2, $result );
-		$result = count_authors( 'Author One' );
+		$result = count_items( 'Author One' );
 		$this->assertEquals( 1, $result );
-		$result = count_authors( '' );
+		$result = count_items( '' );
 		$this->assertEquals( 0, $result );
+		$this->assertEquals( 3, count_items( ['Item one', 'Item two', 'Item 3'] ) );
+		$this->assertEquals( 1, count_items( ['Item one'] ) );
+		$this->assertEquals( 0, count_items( [] ) );
 	}
 
 	function test_do_license() {


### PR DESCRIPTION
Partial fix for pressbooks/pressbooks-aldine#305

This PR adds the [newly created](https://github.com/pressbooks/pressbooks/pull/2587) Institutions info to the book homepage.

#### How to test

1. Add one or more institutions to the book in the Book Info option
2. Go to the book homepage and check if the information is displayed properly (when the book has no institutions, this won't be shown in the homepage)