### PR TITLE
feat: Support new institution structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This theme is named after Canadian media theorist Marshall McLuhan, who coined t
 
 * PHP >= 7.3
 * WordPress >= 5.8.2
-* Pressbooks >= 5.31.0
+* Pressbooks >= 5.32.0
 
 ## Installation
 

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -756,3 +756,16 @@ function get_h5p_activities( $per_page = 20 ) {
 		'pagination' => $pagination,
 	];
 }
+
+/**
+ * Return a comma separated string of all institutions.
+ *
+ * @param array $institutions
+ *
+ * @return string
+ */
+function institutions_to_string( array $institutions ): string {
+	return implode( ', ', array_map( static function( $code ) {
+		return \Pressbooks\Metadata\get_institution_by_code( $code );
+	}, $institutions ) );
+}

--- a/partials/content-cover-metadata.php
+++ b/partials/content-cover-metadata.php
@@ -34,7 +34,7 @@
 								}
 								$book_information[ $key ] = implode( ', ', $output );
 							} elseif ( 'pb_institutions' === $key ) {
-								$book_information[ $key ] = implode( ', ', $book_information[ $key ] );
+								$book_information[ $key ] = \PressbooksBook\Helpers\institutions_to_string( $book_information[ $key ] );
 							} elseif ( 'pb_book_doi' === $key ) {
 								/**
 								 * Filter the DOI resolver service URL (default: https://dx.doi.org).


### PR DESCRIPTION
Partial fix for pressbooks/pressbooks#2595

This PR adds support to the structural changes in the institutions field (see pressbooks/pressbooks#2602).

#### How to test

1. Add one or more institutions to the book in the Book Info option
1. Go to the book homepage and check if the information is displayed properly (when the book has no institutions, this won't be shown in the homepage)