### PR TITLE
Adding aria-label for arrows as required by WCAG

### DIFF
--- a/assets/src/scripts/routes/common.js
+++ b/assets/src/scripts/routes/common.js
@@ -53,7 +53,7 @@ export default {
 				heading.innerHTML = `
 				<button type="button" aria-expanded="false">
 					${heading.innerHTML}
-					<svg role="img" class="arrow" aria-label="${heading.innerHTML}" width="13" height="8" viewBox="0 0 13 8" xmlns="http://www.w3.org/2000/svg"><path d="M6.255 8L0 0h12.51z" fill="currentColor" fill-rule="evenodd"></path></svg>
+					<svg role="presentation" focusable="false" class="arrow" width="13" height="8" viewBox="0 0 13 8" xmlns="http://www.w3.org/2000/svg"><path d="M6.255 8L0 0h12.51z" fill="currentColor" fill-rule="evenodd"></path></svg>
 				</button>
 				`;
 

--- a/assets/src/scripts/routes/common.js
+++ b/assets/src/scripts/routes/common.js
@@ -53,7 +53,7 @@ export default {
 				heading.innerHTML = `
 				<button type="button" aria-expanded="false">
 					${heading.innerHTML}
-					<svg role="img" class="arrow" width="13" height="8" viewBox="0 0 13 8" xmlns="http://www.w3.org/2000/svg"><path d="M6.255 8L0 0h12.51z" fill="currentColor" fill-rule="evenodd"></path></svg>
+					<svg role="img" class="arrow" aria-label="${heading.innerHTML}" width="13" height="8" viewBox="0 0 13 8" xmlns="http://www.w3.org/2000/svg"><path d="M6.255 8L0 0h12.51z" fill="currentColor" fill-rule="evenodd"></path></svg>
 				</button>
 				`;
 


### PR DESCRIPTION
WCAG requires svgs used as images to be labeled in the same way as a standard images. Currently the up/down areas in the TOC area are not labeled for accessibility.

This commit will append the passed naming of the TOC - ie "Content" to also map to the up/down arrows aria labels which performs more consistently that alt or labeledby in this context.