### PR TITLE
feat: support edited volumes and other contributor types

### DIFF
--- a/assets/src/styles/layouts/_cover.scss
+++ b/assets/src/styles/layouts/_cover.scss
@@ -79,11 +79,11 @@
 }
 
 .book-header__contributor {
-  @extend .book-header__author
+  @extend .book-header__author;
 }
 
 .book-header__author + .book-header__contributor {
-  @extend .book-header__author
+  @extend .book-header__author;
 }
 
 .book-header__cover {

--- a/assets/src/styles/layouts/_cover.scss
+++ b/assets/src/styles/layouts/_cover.scss
@@ -78,6 +78,14 @@
   }
 }
 
+.book-header__editor {
+  @extend .book-header__author
+}
+
+.book-header__author + .book-header__editor {
+  @extend .book-header__author
+}
+
 .book-header__cover {
   align-self: center;
   margin-bottom: 1.5rem;

--- a/assets/src/styles/layouts/_cover.scss
+++ b/assets/src/styles/layouts/_cover.scss
@@ -78,11 +78,11 @@
   }
 }
 
-.book-header__editor {
+.book-header__contributor {
   @extend .book-header__author
 }
 
-.book-header__author + .book-header__editor {
+.book-header__author + .book-header__contributor {
   @extend .book-header__author
 }
 

--- a/packages/buckram/assets/styles/components/structure/_content-strings.scss
+++ b/packages/buckram/assets/styles/components/structure/_content-strings.scss
@@ -24,6 +24,10 @@ meta[name="pb-authors"] {
   string-set: book-author attr('content');
 }
 
+meta[name="pb-editors"] {
+  string-set: book-editor attr('content');
+}
+
 meta[name="pb-publisher"] {
   string-set: book-publisher attr('content');
 }

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -17,13 +17,13 @@ use function \Pressbooks\Image\attachment_id_from_url;
 			<p class="book-header__author"><span class="screen-reader-text"><?php echo translate_nooped_plural( _n_noop( 'Author', 'Authors', 'pressbooks-book' ), \PressbooksBook\Helpers\count_items( $book_information['pb_authors'] ), 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_authors']; ?></p>
 		<?php } ?>
 		<?php if ( ! empty( $book_information['pb_editors'] ) ) { ?>
-			<p class="book-header__editor"><?php _e( 'Edited By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_editors']; ?></p>
+			<p class="book-header__contributor"><?php _e( 'Edited By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_editors']; ?></p>
 		<?php } ?>
 		<?php if ( ! empty( $book_information['pb_translators'] ) ) { ?>
-			<p class="book-header__editor"><?php _e( 'Translated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_translators']; ?></p>
+			<p class="book-header__contributor"><?php _e( 'Translated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_translators']; ?></p>
 		<?php } ?>
 		<?php if ( ! empty( $book_information['pb_illustrators'] ) ) { ?>
-			<p class="book-header__editor"><?php _e( 'Illustrated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_illustrators']; ?></p>
+			<p class="book-header__contributor"><?php _e( 'Illustrated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_illustrators']; ?></p>
 		<?php } ?>
 		<div class="book-header__cover">
 			<?php if ( ! empty( $book_information['pb_cover_image'] ) ) { ?>

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -16,6 +16,9 @@ use function \Pressbooks\Image\attachment_id_from_url;
 		<?php if ( ! empty( $book_information['pb_authors'] ) ) { ?>
 			<p class="book-header__author"><span class="screen-reader-text"><?php echo translate_nooped_plural( _n_noop( 'Author', 'Authors', 'pressbooks-book' ), \PressbooksBook\Helpers\count_items( $book_information['pb_authors'] ), 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_authors']; ?></p>
 		<?php } ?>
+		<?php if ( ! empty( $book_information['pb_editors'] ) ) { ?>
+			<p class="book-header__editor"><?php _e( 'Edited By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_editors']; ?></p>
+		<?php } ?>
 		<div class="book-header__cover">
 			<?php if ( ! empty( $book_information['pb_cover_image'] ) ) { ?>
 				<div class="book-header__cover__image">

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -22,6 +22,9 @@ use function \Pressbooks\Image\attachment_id_from_url;
 		<?php if ( ! empty( $book_information['pb_translators'] ) ) { ?>
 			<p class="book-header__editor"><?php _e( 'Translated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_translators']; ?></p>
 		<?php } ?>
+		<?php if ( ! empty( $book_information['pb_illustrators'] ) ) { ?>
+			<p class="book-header__editor"><?php _e( 'Illustrated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_illustrators']; ?></p>
+		<?php } ?>
 		<div class="book-header__cover">
 			<?php if ( ! empty( $book_information['pb_cover_image'] ) ) { ?>
 				<div class="book-header__cover__image">

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -19,6 +19,9 @@ use function \Pressbooks\Image\attachment_id_from_url;
 		<?php if ( ! empty( $book_information['pb_editors'] ) ) { ?>
 			<p class="book-header__editor"><?php _e( 'Edited By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_editors']; ?></p>
 		<?php } ?>
+		<?php if ( ! empty( $book_information['pb_translators'] ) ) { ?>
+			<p class="book-header__editor"><?php _e( 'Translated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_translators']; ?></p>
+		<?php } ?>
 		<div class="book-header__cover">
 			<?php if ( ! empty( $book_information['pb_cover_image'] ) ) { ?>
 				<div class="book-header__cover__image">

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -17,13 +17,13 @@ use function \Pressbooks\Image\attachment_id_from_url;
 			<p class="book-header__author"><span class="screen-reader-text"><?php echo translate_nooped_plural( _n_noop( 'Author', 'Authors', 'pressbooks-book' ), \PressbooksBook\Helpers\count_items( $book_information['pb_authors'] ), 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_authors']; ?></p>
 		<?php } ?>
 		<?php if ( ! empty( $book_information['pb_editors'] ) ) { ?>
-			<p class="book-header__contributor"><?php _e( 'Edited By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_editors']; ?></p>
+			<p class="book-header__contributor"><?php _e( 'Edited By ', 'pressbooks-book' ); ?> <?php echo $book_information['pb_editors']; ?></p>
 		<?php } ?>
 		<?php if ( ! empty( $book_information['pb_translators'] ) ) { ?>
-			<p class="book-header__contributor"><?php _e( 'Translated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_translators']; ?></p>
+			<p class="book-header__contributor"><?php _e( 'Translated By ', 'pressbooks-book' ); ?> <?php echo $book_information['pb_translators']; ?></p>
 		<?php } ?>
 		<?php if ( ! empty( $book_information['pb_illustrators'] ) ) { ?>
-			<p class="book-header__contributor"><?php _e( 'Illustrated By', 'pressbooks-book' ); ?>: <?php echo $book_information['pb_illustrators']; ?></p>
+			<p class="book-header__contributor"><?php _e( 'Illustrated By ', 'pressbooks-book' ); ?> <?php echo $book_information['pb_illustrators']; ?></p>
 		<?php } ?>
 		<div class="book-header__cover">
 			<?php if ( ! empty( $book_information['pb_cover_image'] ) ) { ?>

--- a/partials/content-cover-book-info.php
+++ b/partials/content-cover-book-info.php
@@ -49,11 +49,17 @@
 </div>
 		<div class="block-info__inner__content">
 			<div class="block-info__subsection block-info__lead-author">
-				<h3 class="block__subtitle"><?php echo _n( 'Author', 'Authors', \PressbooksBook\Helpers\count_items( $book_information['pb_authors'] ), 'pressbooks-book' ); ?></h3>
 				<?php if ( ! empty( $book_information['pb_authors'] ) ) { ?>
+				<h3 class="block__subtitle"><?php echo _n( 'Author', 'Authors', \PressbooksBook\Helpers\count_items( $book_information['pb_authors'] ), 'pressbooks-book' ); ?></h3>
 					<div class="block-info__authors">
 						<?php // TODO add author photo ?>
 						<span class="block-info__author__names"><?php echo $book_information['pb_authors']; ?></span>
+					</div>
+				<?php } elseif ( ! empty( $book_information['pb_editors'] ) ) { ?>
+				<h3 class="block__subtitle"><?php echo _n( 'Editor', 'Editors', \PressbooksBook\Helpers\count_items( $book_information['pb_editors'] ), 'pressbooks-book' ); ?></h3>
+					<div class="block-info__authors">
+						<?php // TODO add editor photo ?>
+						<span class="block-info__author__names"><?php echo $book_information['pb_editors']; ?></span>
 					</div>
 				<?php } ?>
 			</div>


### PR DESCRIPTION
This allows the publishing of Edited Volumes and other books that don't have a book level author, as well as implementing the other parameters that @SteelWagstaff outlined here [idea/issue134](https://github.com/pressbooks/ideas/issues/134#issuecomment-944830722) that display other contributor types on title pages. 

This pull request works in conjunction with the corresponding pressbooks[ pull request](https://github.com/pressbooks/pressbooks/pull/2657). See that pull request for testing and details.