### PR TITLE
Fix aria label for site logo

### DIFF
--- a/header.php
+++ b/header.php
@@ -63,13 +63,13 @@
 	<header class="header" role="banner">
 		<div class="header__inside">
 			<div class="header__brand">
+				<?php
+				$root_id = get_network()->site_id;
+				switch_to_blog( $root_id );
+				?>
 				<a aria-label="<?php echo get_bloginfo( 'name', 'display' ); ?>" href="<?php echo network_home_url(); ?>">
 					<?php
-					$root_id = get_network()->site_id;
 					if ( has_custom_logo( $root_id ) ) {
-						?>
-						<?php
-						switch_to_blog( $root_id );
 						$custom_logo_id = get_theme_mod( 'custom_logo' );
 						printf(
 							'<img class="header__logo--img" src="%1$s" srcset="%2$s" alt="%3$s" />',
@@ -78,12 +78,15 @@
 							/* translators: %s: name of network */
 							sprintf( __( 'Logo for %s', 'pressbooks-book' ), get_bloginfo( 'name', 'display' ) )
 						);
-						restore_current_blog();
+					} else {
 						?>
-					<?php } else { ?>
 					<svg class="header__logo--svg" role="img">
 						<use href="#logo-pressbooks" />
-					</svg><?php } ?>
+					</svg>
+						<?php
+					}
+					restore_current_blog();
+					?>
 				</a>
 			</div>
 			<div class="header__nav">


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks-book/issues/998

To test:
1. Change the default logo for your network (`wp-admin/customize.php?return=%2Fwp%2Fwp-admin%2F`)
2. Visit the home page of a book and inspect the logo. Aria label should now be the title of your network, not the title of the book.
3. Change the Site Title for your network
4. Visit the home page of a book and inspect the logo. Aria label should now be the updated network Site Title.