### PR TITLE
fix Alegreya Sans font import

### DIFF
--- a/assets/book/typography/styles/_shapeshifter-font-stack-epub.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-epub.scss
@@ -21,9 +21,9 @@ $shapeshifter-fonts: ();
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
     @scssphp-import-once 'SpectralFont';
-  } @else if unquote($font) == 'Alegreya' {
+  } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'AlegreyaSansSCFont';
+    @scssphp-import-once 'AlegreyaSansFont';
   } @else if unquote($font) == 'Crimson Text' {
     // noinspection CssInvalidAtRule
     @scssphp-import-once 'CrimsonTextFont';

--- a/assets/book/typography/styles/_shapeshifter-font-stack-prince.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-prince.scss
@@ -21,9 +21,9 @@ $shapeshifter-fonts: ();
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
     @scssphp-import-once 'SpectralFont';
-  } @else if unquote($font) == 'Alegreya' {
+  } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'AlegreyaSansSCFont';
+    @scssphp-import-once 'AlegreyaSansFont';
   } @else if unquote($font) == 'Crimson Text' {
     // noinspection CssInvalidAtRule
     @scssphp-import-once 'CrimsonTextFont';

--- a/assets/book/typography/styles/_shapeshifter-font-stack-web.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-web.scss
@@ -21,7 +21,7 @@ $shapeshifter-fonts: ();
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
     @scssphp-import-once 'https://fonts.googleapis.com/css?family=Spectral|Spectral+SC&display=swap';
-  } @else if unquote($font) == 'Alegreya' {
+  } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
     @scssphp-import-once 'https://fonts.googleapis.com/css?family=Alegreya|Alegreya+SC|Alegreya+Sans|Alegreya+Sans+SC&display=swap';
   } @else if unquote($font) == 'Crimson Text' {


### PR DESCRIPTION
Partial fix for https://github.com/pressbooks/pressbooks-book/issues/932. Requires https://github.com/pressbooks/pressbooks/pull/2798

To test:
1. Apply the McLuhan or Malala theme to your book
2. Go to theme options: and select Alegreya Sans as the header or body font for web, pdf, and epub exports
![Screenshot from 2022-05-20 08-34-21](https://user-images.githubusercontent.com/13485451/169562542-9c9b6a94-0e0f-4698-9541-3571c6b3bc99.png)
3. View the webbook and confirm that the font displayed is Alegreya Sans
![Screenshot from 2022-05-20 08-36-17](https://user-images.githubusercontent.com/13485451/169562858-0ae1ab75-cf06-4d8e-82d9-2a39bb2c2676.png)
4. Produce and EPUB and PDF exports and confirm that the fonts displayed are Alegreya Sans
![Screenshot from 2022-05-20 08-35-03](https://user-images.githubusercontent.com/13485451/169562644-ab42056c-5155-43a5-804f-7e9f7b36d6ef.png)