### PR TITLE
Allow custom styles to be applied to book home page

### DIFF
--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -70,6 +70,40 @@ function enqueue_assets() {
 		]
 	);
 
+	if ( pb_is_custom_theme() ) { // Custom CSS is no longer supported.
+		$styles   = Container::get( 'Styles' );
+		$sass     = Container::get( 'Sass' );
+		$fullpath = $sass->pathToUserGeneratedCss() . '/style.css';
+		if ( ! @is_file( $fullpath ) ) { // @codingStandardsIgnoreLine
+			$styles->updateWebBookStyleSheet( 'pressbooks-book' );
+		}
+		wp_enqueue_style( 'pressbooks/theme', $sass->urlToUserGeneratedCss() . '/style.css', false, @filemtime( $fullpath ), 'screen, print' ); // @codingStandardsIgnoreLine
+	} else {
+		$styles = Container::get( 'Styles' );
+		if ( $styles->isCurrentThemeCompatible( 1 ) ) {
+			// Supplementary webbook styles for older themes.
+			wp_enqueue_style( 'pressbooks/web-house-style', $assets->getPath( 'styles/web-house-style.css' ), false, null );
+		}
+		if ( $styles->isCurrentThemeCompatible( 1 ) || $styles->isCurrentThemeCompatible( 2 ) ) {
+			$sass = Container::get( 'Sass' );
+			// Custom Styles
+			if ( get_stylesheet() === 'pressbooks-book' && ! get_option( 'pressbooks_webbook_structure_version' ) ) {
+				$styles->updateWebBookStyleSheet();
+				update_option( 'pressbooks_webbook_structure_version', 1 );
+			}
+			$fullpath = $sass->pathToUserGeneratedCss() . '/style.css';
+			if ( ! @is_file( $fullpath ) ) { // @codingStandardsIgnoreLine
+				$styles->updateWebBookStyleSheet();
+			}
+			if ( $styles->isCurrentThemeCompatible( 1 ) && get_stylesheet() !== 'pressbooks-book' ) {
+				wp_enqueue_style( 'pressbooks/book', get_template_directory_uri() . '/style.css', false, null, 'screen, print' );
+			}
+			wp_enqueue_style( 'pressbooks/theme', $sass->urlToUserGeneratedCss() . '/style.css', false, @filemtime( $fullpath ), 'screen, print' ); // @codingStandardsIgnoreLine
+		} else {
+			// Classic mode (does not use Sass)
+			wp_enqueue_style( 'pressbooks/theme', get_stylesheet_directory_uri() . '/style.css', false, null, 'screen, print' );
+		}
+	}
 	if ( ! is_front_page() ) {
 		if ( isset( $options['collapse_sections'] ) && absint( $options['collapse_sections'] ) === 1 ) {
 			wp_enqueue_script( 'pressbooks/collapse-sections', $assets->getPath( 'scripts/collapse-sections.js' ), false, null );
@@ -79,41 +113,6 @@ function enqueue_assets() {
 			wp_enqueue_script( 'lity', $assets->getPath( 'scripts/lity.js' ), [ 'jquery' ], null );
 			wp_enqueue_style( 'lity', $assets->getPath( 'styles/lity.css' ), false, null );
 			wp_enqueue_script( 'pressbooks/lightbox', $assets->getPath( 'scripts/lightbox.js' ), false, null );
-		}
-
-		if ( pb_is_custom_theme() ) { // Custom CSS is no longer supported.
-			$styles   = Container::get( 'Styles' );
-			$sass     = Container::get( 'Sass' );
-			$fullpath = $sass->pathToUserGeneratedCss() . '/style.css';
-			if ( ! @is_file( $fullpath ) ) { // @codingStandardsIgnoreLine
-				$styles->updateWebBookStyleSheet( 'pressbooks-book' );
-			}
-			wp_enqueue_style( 'pressbooks/theme', $sass->urlToUserGeneratedCss() . '/style.css', false, @filemtime( $fullpath ), 'screen, print' ); // @codingStandardsIgnoreLine
-		} else {
-			$styles = Container::get( 'Styles' );
-			if ( $styles->isCurrentThemeCompatible( 1 ) ) {
-				// Supplementary webbook styles for older themes.
-				wp_enqueue_style( 'pressbooks/web-house-style', $assets->getPath( 'styles/web-house-style.css' ), false, null );
-			}
-			if ( $styles->isCurrentThemeCompatible( 1 ) || $styles->isCurrentThemeCompatible( 2 ) ) {
-				$sass = Container::get( 'Sass' );
-				// Custom Styles
-				if ( get_stylesheet() === 'pressbooks-book' && ! get_option( 'pressbooks_webbook_structure_version' ) ) {
-					$styles->updateWebBookStyleSheet();
-					update_option( 'pressbooks_webbook_structure_version', 1 );
-				}
-				$fullpath = $sass->pathToUserGeneratedCss() . '/style.css';
-				if ( ! @is_file( $fullpath ) ) { // @codingStandardsIgnoreLine
-					$styles->updateWebBookStyleSheet();
-				}
-				if ( $styles->isCurrentThemeCompatible( 1 ) && get_stylesheet() !== 'pressbooks-book' ) {
-					wp_enqueue_style( 'pressbooks/book', get_template_directory_uri() . '/style.css', false, null, 'screen, print' );
-				}
-				wp_enqueue_style( 'pressbooks/theme', $sass->urlToUserGeneratedCss() . '/style.css', false, @filemtime( $fullpath ), 'screen, print' ); // @codingStandardsIgnoreLine
-			} else {
-				// Classic mode (does not use Sass)
-				wp_enqueue_style( 'pressbooks/theme', get_stylesheet_directory_uri() . '/style.css', false, null, 'screen, print' );
-			}
 		}
 	}
 }


### PR DESCRIPTION
At present, users can apply 'custom styles' to alter the CSS of their webbook, EPUB and PDF exports. CSS that they enter through this feature is applied to every page inside of a book, but was NOT applied to the webbook home page itself. This is unexpected behaviour, since custom CSS is already applied to every page within the book's reading interface (front matter, chapters, etc), as well as the buy book page. This PR enqueues these custom styles on book homepages, so CSS changes appear on this page as well.

To test:
1. Apply custom web styles that target some element of the webbook home page. For example: 
```
.cta {
  display: none;
}

.home .book-header__title {
  color: pink;
}
```
2. Observe no change to the webbook homepage.
3. Check out this branch
4. Observe that the webbook homepage styles have been altered/updated
![Screenshot from 2022-07-08 09-52-44](https://user-images.githubusercontent.com/13485451/178036396-739e664b-e178-46fe-bd36-0f9ba09f1602.png)

