### PR TITLE
feat: display CTA banner when wp option is != 0

### DIFF
--- a/header.php
+++ b/header.php
@@ -99,7 +99,7 @@
 				</nav>
 			</div>
 		</div>
-		<?php if ( \PressbooksBook\Helpers\is_book_public() ) : ?>
+		<?php if ( \PressbooksBook\Helpers\should_cta_banner_being_displayed() && \PressbooksBook\Helpers\is_book_public() ) : ?>
 		<div class="cta hidden">
 			<p><?php echo sprintf( esc_html__( 'Want to create or adapt books like this? %s about how Pressbooks supports open publishing practices.', 'pressbooks-book' ), sprintf( '<a href="%1$s" target="_blank">%2$s</a>', esc_url( 'https://pressbooks.com/adapt-open-textbooks?utm_source=book&utm_medium=banner&utm_campaign=bbc' ), esc_html__( 'Learn more', 'pressbook-book' ) ) ); ?>
 				<a id="close-cta" href="javascript:void()" title="Close banner">

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -2,6 +2,7 @@
 
 namespace PressbooksBook\Helpers;
 
+use Pressbooks\Admin\Network\NetworkSettings;
 use Pressbooks\Container;
 
 /**
@@ -540,6 +541,15 @@ function is_book_public() {
 		return true;
 	}
 	return false;
+}
+
+/**
+ * Determine if CTA banner should be displayed.
+ *
+ * @return bool
+ */
+function should_cta_banner_being_displayed() {
+	return get_site_option( NetworkSettings::DISPLAY_CTA_BANNER_OPTION, '1' ) === '1';
 }
 
 /**

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -19,9 +19,12 @@ use function \PressbooksBook\Helpers\license_to_icons;
 use function \PressbooksBook\Helpers\license_to_text;
 use function \PressbooksBook\Helpers\share_icons;
 use function \PressbooksBook\Helpers\social_media_enabled;
+use function \PressbooksBook\Helpers\should_cta_banner_being_displayed;
 
 /**
  * Helpers test case.
+ *
+ * @group helpers
  */
 class HelpersTest extends WP_UnitTestCase {
 
@@ -236,5 +239,16 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( '1', $data['total'] );
 		$this->assertEquals( 1, count( $data['activities'] ) );
 		$this->assertEquals( $_GET['h5p_id'], $data['activities'][0]['ID'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_test_should_cta_banner_beign_displayed_method(): void {
+		update_site_option( \Pressbooks\Admin\Network\NetworkSettings::DISPLAY_CTA_BANNER_OPTION, '1' );
+		$this->assertTrue( should_cta_banner_being_displayed() );
+
+		update_site_option( \Pressbooks\Admin\Network\NetworkSettings::DISPLAY_CTA_BANNER_OPTION, '0' );
+		$this->assertFalse( should_cta_banner_being_displayed() );
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-network-analytics/issues/254

This PR allows to display the CTA banner when `pressbooks_display_cta_banner` wp option is `'1'`. If the option is not present, when by default it would be displayed anyway.

For testing see: https://github.com/pressbooks/pressbooks/pull/2953. The PR mentioned must be in place to test it properly.