### PR TITLE
Change redirect behaviour after signing in from private book content

### DIFF
--- a/private.php
+++ b/private.php
@@ -10,7 +10,7 @@
 				__( 'This book is private, and accessible only to registered users. If you have an account you can %s.', 'pressbooks-book' ),
 				sprintf(
 					'<a href="%1$s">%2$s</a>',
-					wp_login_url(),
+					wp_login_url( get_permalink() ),
 					__( 'sign in here', 'pressbooks-book' )
 				)
 			);


### PR DESCRIPTION
Fix for https://github.com/pressbooks/private/issues/1018

To test:
1. Set a book to private
2. Visit the book home page and sign in -- you should be redirected to the home page instead of the admin menu
3. Visit any 'show in web' content inside the book and sign in -- you should be redirected to the page you signed in from instead of the admin menu