### PR TITLE
fix: replace @phpscss-import-once directive with @import

### DIFF
--- a/assets/book/typography/styles/_shapeshifter-font-stack-epub.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-epub.scss
@@ -14,64 +14,64 @@ $shapeshifter-fonts: ();
 @each $font in $shapeshifter-fonts {
   @if unquote($font) == 'Cormorant Garamond' {
     // noinspection CssInvalidAtRule
-    @use 'CormorantGaramondFont';
+    @import'CormorantGaramondFont';
   } @else if unquote($font) == 'Noto Serif' {
     // noinspection CssInvalidAtRule
-    @use 'NotoSerifFont';
+    @import'NotoSerifFont';
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
-    @use 'SpectralFont';
+    @import'SpectralFont';
   } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
-    @use 'AlegreyaSansFont';
+    @import'AlegreyaSansFont';
   } @else if unquote($font) == 'Crimson Text' {
     // noinspection CssInvalidAtRule
-    @use 'CrimsonTextFont';
+    @import'CrimsonTextFont';
   } @else if unquote($font) == 'Roboto' {
     // noinspection CssInvalidAtRule
-    @use 'RobotoFont';
+    @import'RobotoFont';
   } @else if unquote($font) == 'Open Sans' {
     // noinspection CssInvalidAtRule
-    @use 'OpenSansFont';
+    @import'OpenSansFont';
   } @else if unquote($font) == 'Lato' {
     // noinspection CssInvalidAtRule
-    @use 'LatoFont';
+    @import'LatoFont';
   } @else if unquote($font) == 'Montserrat' {
     // noinspection CssInvalidAtRule
-    @use 'MontserratFont';
+    @import'MontserratFont';
   } @else if unquote($font) == 'Raleway' {
     // noinspection CssInvalidAtRule
-    @use 'RalewayFont';
+    @import'RalewayFont';
   } @else if unquote($font) == 'Noto Sans' {
     // noinspection CssInvalidAtRule
-    @use 'NotoSansFont';
+    @import'NotoSansFont';
   } @else if unquote($font) == 'Rubik' {
     // noinspection CssInvalidAtRule
-    @use 'RubikFont';
+    @import'RubikFont';
   } @else if unquote($font) == 'Barlow' {
     // noinspection CssInvalidAtRule
-    @use 'BarlowFont';
+    @import'BarlowFont';
     // noinspection CssInvalidAtRule
   } @else if unquote($font) == 'Libre Franklin' {
     // noinspection CssInvalidAtRule
-    @use 'LibreFranklinFont';
+    @import'LibreFranklinFont';
   } @else if unquote($font) == 'K2D' {
     // noinspection CssInvalidAtRule
-    @use 'K2DFont';
+    @import'K2DFont';
   } @else if unquote($font) == 'FreeSans' {
     // noinspection CssInvalidAtRule
-    @use 'FreeSans';
+    @import'FreeSans';
   } @else if unquote($font) == 'FreeSerif' {
     // noinspection CssInvalidAtRule
-    @use 'FreeSerif';
+    @import'FreeSerif';
   } @else if unquote($font) == 'Source Sans Pro' {
     // noinspection CssInvalidAtRule
-    @use 'SourceSansProFont';
+    @import'SourceSansProFont';
   } @else if unquote($font) == 'Sorts Mill Goudy' {
     // noinspection CssInvalidAtRule
-    @use 'SortsMillGoudyFont';
+    @import'SortsMillGoudyFont';
   } @else if unquote($font) == 'New Athena Unicode' {
     // noinspection CssInvalidAtRule
-    @use 'NewAthenaUnicodeFont';
+    @import'NewAthenaUnicodeFont';
   }
 }

--- a/assets/book/typography/styles/_shapeshifter-font-stack-epub.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-epub.scss
@@ -14,64 +14,64 @@ $shapeshifter-fonts: ();
 @each $font in $shapeshifter-fonts {
   @if unquote($font) == 'Cormorant Garamond' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'CormorantGaramondFont';
+    @use 'CormorantGaramondFont';
   } @else if unquote($font) == 'Noto Serif' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'NotoSerifFont';
+    @use 'NotoSerifFont';
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'SpectralFont';
+    @use 'SpectralFont';
   } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'AlegreyaSansFont';
+    @use 'AlegreyaSansFont';
   } @else if unquote($font) == 'Crimson Text' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'CrimsonTextFont';
+    @use 'CrimsonTextFont';
   } @else if unquote($font) == 'Roboto' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'RobotoFont';
+    @use 'RobotoFont';
   } @else if unquote($font) == 'Open Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'OpenSansFont';
+    @use 'OpenSansFont';
   } @else if unquote($font) == 'Lato' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'LatoFont';
+    @use 'LatoFont';
   } @else if unquote($font) == 'Montserrat' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'MontserratFont';
+    @use 'MontserratFont';
   } @else if unquote($font) == 'Raleway' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'RalewayFont';
+    @use 'RalewayFont';
   } @else if unquote($font) == 'Noto Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'NotoSansFont';
+    @use 'NotoSansFont';
   } @else if unquote($font) == 'Rubik' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'RubikFont';
+    @use 'RubikFont';
   } @else if unquote($font) == 'Barlow' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'BarlowFont';
+    @use 'BarlowFont';
     // noinspection CssInvalidAtRule
   } @else if unquote($font) == 'Libre Franklin' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'LibreFranklinFont';
+    @use 'LibreFranklinFont';
   } @else if unquote($font) == 'K2D' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'K2DFont';
+    @use 'K2DFont';
   } @else if unquote($font) == 'FreeSans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'FreeSans';
+    @use 'FreeSans';
   } @else if unquote($font) == 'FreeSerif' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'FreeSerif';
+    @use 'FreeSerif';
   } @else if unquote($font) == 'Source Sans Pro' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'SourceSansProFont';
+    @use 'SourceSansProFont';
   } @else if unquote($font) == 'Sorts Mill Goudy' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'SortsMillGoudyFont';
+    @use 'SortsMillGoudyFont';
   } @else if unquote($font) == 'New Athena Unicode' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'NewAthenaUnicodeFont';
+    @use 'NewAthenaUnicodeFont';
   }
 }

--- a/assets/book/typography/styles/_shapeshifter-font-stack-prince.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-prince.scss
@@ -14,64 +14,64 @@ $shapeshifter-fonts: ();
 @each $font in $shapeshifter-fonts {
   @if unquote($font) == 'Cormorant Garamond' {
     // noinspection CssInvalidAtRule
-    @use 'CormorantGaramondFont';
+    @import'CormorantGaramondFont';
   } @else if unquote($font) == 'Noto Serif' {
     // noinspection CssInvalidAtRule
-    @use 'NotoSerifFont';
+    @import'NotoSerifFont';
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
-    @use 'SpectralFont';
+    @import'SpectralFont';
   } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
-    @use 'AlegreyaSansFont';
+    @import'AlegreyaSansFont';
   } @else if unquote($font) == 'Crimson Text' {
     // noinspection CssInvalidAtRule
-    @use 'CrimsonTextFont';
+    @import'CrimsonTextFont';
   } @else if unquote($font) == 'Roboto' {
     // noinspection CssInvalidAtRule
-    @use 'RobotoFont';
+    @import'RobotoFont';
   } @else if unquote($font) == 'Open Sans' {
     // noinspection CssInvalidAtRule
-    @use 'OpenSansFont';
+    @import'OpenSansFont';
   } @else if unquote($font) == 'Lato' {
     // noinspection CssInvalidAtRule
-    @use 'LatoFont';
+    @import'LatoFont';
   } @else if unquote($font) == 'Montserrat' {
     // noinspection CssInvalidAtRule
-    @use 'MontserratFont';
+    @import'MontserratFont';
   } @else if unquote($font) == 'Raleway' {
     // noinspection CssInvalidAtRule
-    @use 'RalewayFont';
+    @import'RalewayFont';
   } @else if unquote($font) == 'Noto Sans' {
     // noinspection CssInvalidAtRule
-    @use 'NotoSansFont';
+    @import'NotoSansFont';
   } @else if unquote($font) == 'Rubik' {
     // noinspection CssInvalidAtRule
-    @use 'RubikFont';
+    @import'RubikFont';
   } @else if unquote($font) == 'Barlow' {
     // noinspection CssInvalidAtRule
-    @use 'BarlowFont';
+    @import'BarlowFont';
     // noinspection CssInvalidAtRule
   } @else if unquote($font) == 'Libre Franklin' {
     // noinspection CssInvalidAtRule
-    @use 'LibreFranklinFont';
+    @import'LibreFranklinFont';
   } @else if unquote($font) == 'K2D' {
     // noinspection CssInvalidAtRule
-    @use 'K2DFont';
+    @import'K2DFont';
   } @else if unquote($font) == 'FreeSans' {
     // noinspection CssInvalidAtRule
-    @use 'FreeSans';
+    @import'FreeSans';
   } @else if unquote($font) == 'FreeSerif' {
     // noinspection CssInvalidAtRule
-    @use 'FreeSerif';
+    @import'FreeSerif';
   } @else if unquote($font) == 'SourceSansPro' {
     // noinspection CssInvalidAtRule
-    @use 'SourceSansProFont';
+    @import'SourceSansProFont';
   } @else if unquote($font) == 'Sorts Mill Goudy' {
     // noinspection CssInvalidAtRule
-    @use 'SortsMillGoudyFont';
+    @import'SortsMillGoudyFont';
   } @else if unquote($font) == 'New Athena Unicode' {
     // noinspection CssInvalidAtRule
-    @use 'NewAthenaUnicodeFont';
+    @import'NewAthenaUnicodeFont';
   }
 }

--- a/assets/book/typography/styles/_shapeshifter-font-stack-prince.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-prince.scss
@@ -14,64 +14,64 @@ $shapeshifter-fonts: ();
 @each $font in $shapeshifter-fonts {
   @if unquote($font) == 'Cormorant Garamond' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'CormorantGaramondFont';
+    @use 'CormorantGaramondFont';
   } @else if unquote($font) == 'Noto Serif' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'NotoSerifFont';
+    @use 'NotoSerifFont';
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'SpectralFont';
+    @use 'SpectralFont';
   } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'AlegreyaSansFont';
+    @use 'AlegreyaSansFont';
   } @else if unquote($font) == 'Crimson Text' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'CrimsonTextFont';
+    @use 'CrimsonTextFont';
   } @else if unquote($font) == 'Roboto' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'RobotoFont';
+    @use 'RobotoFont';
   } @else if unquote($font) == 'Open Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'OpenSansFont';
+    @use 'OpenSansFont';
   } @else if unquote($font) == 'Lato' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'LatoFont';
+    @use 'LatoFont';
   } @else if unquote($font) == 'Montserrat' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'MontserratFont';
+    @use 'MontserratFont';
   } @else if unquote($font) == 'Raleway' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'RalewayFont';
+    @use 'RalewayFont';
   } @else if unquote($font) == 'Noto Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'NotoSansFont';
+    @use 'NotoSansFont';
   } @else if unquote($font) == 'Rubik' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'RubikFont';
+    @use 'RubikFont';
   } @else if unquote($font) == 'Barlow' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'BarlowFont';
+    @use 'BarlowFont';
     // noinspection CssInvalidAtRule
   } @else if unquote($font) == 'Libre Franklin' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'LibreFranklinFont';
+    @use 'LibreFranklinFont';
   } @else if unquote($font) == 'K2D' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'K2DFont';
+    @use 'K2DFont';
   } @else if unquote($font) == 'FreeSans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'FreeSans';
+    @use 'FreeSans';
   } @else if unquote($font) == 'FreeSerif' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'FreeSerif';
+    @use 'FreeSerif';
   } @else if unquote($font) == 'SourceSansPro' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'SourceSansProFont';
+    @use 'SourceSansProFont';
   } @else if unquote($font) == 'Sorts Mill Goudy' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'SortsMillGoudyFont';
+    @use 'SortsMillGoudyFont';
   } @else if unquote($font) == 'New Athena Unicode' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'NewAthenaUnicodeFont';
+    @use 'NewAthenaUnicodeFont';
   }
 }

--- a/assets/book/typography/styles/_shapeshifter-font-stack-web.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-web.scss
@@ -14,65 +14,65 @@ $shapeshifter-fonts: ();
 @each $font in $shapeshifter-fonts {
   @if unquote($font) == 'Cormorant Garamond' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Cormorant+Garamond&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Cormorant+Garamond&display=swap';
   } @else if unquote($font) == 'Noto Serif' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Noto+Serif|Noto+Serif+JP|Noto+Serif+KR|Noto+Serif+SC|Noto+Serif+TC&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Noto+Serif|Noto+Serif+JP|Noto+Serif+KR|Noto+Serif+SC|Noto+Serif+TC&display=swap';
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Spectral|Spectral+SC&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Spectral|Spectral+SC&display=swap';
   } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Alegreya|Alegreya+SC|Alegreya+Sans|Alegreya+Sans+SC&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Alegreya|Alegreya+SC|Alegreya+Sans|Alegreya+Sans+SC&display=swap';
   } @else if unquote($font) == 'Crimson Text' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Crimson+Text&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Crimson+Text&display=swap';
   } @else if unquote($font) == 'Roboto' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Roboto&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Roboto&display=swap';
   } @else if unquote($font) == 'Open Sans' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Open+Sans&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Open+Sans&display=swap';
   } @else if unquote($font) == 'Lato' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Lato&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Lato&display=swap';
   } @else if unquote($font) == 'Montserrat' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Montserrat&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Montserrat&display=swap';
   } @else if unquote($font) == 'Raleway' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Raleway&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Raleway&display=swap';
   } @else if unquote($font) == 'Noto Sans' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Noto+Sans|Noto+Sans+HK|Noto+Sans+JP|Noto+Sans+KR|Noto+Sans+SC|Noto+Sans+TC|Raleway&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Noto+Sans|Noto+Sans+HK|Noto+Sans+JP|Noto+Sans+KR|Noto+Sans+SC|Noto+Sans+TC|Raleway&display=swap';
   } @else if unquote($font) == 'Rubik' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Rubik&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Rubik&display=swap';
   } @else if unquote($font) == 'Barlow' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Barlow&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Barlow&display=swap';
     // noinspection CssInvalidAtRule
   } @else if unquote($font) == 'Libre Franklin' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Libre+Franklin&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Libre+Franklin&display=swap';
   } @else if unquote($font) == 'K2D' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=K2D&display=swap';
+    @import'https://fonts.googleapis.com/css?family=K2D&display=swap';
   } @else if unquote($font) == 'FreeSans' {
     // noinspection CssInvalidAtRule
-    @use 'FreeSans';
+    @import'FreeSans';
   } @else if unquote($font) == 'FreeSerif' {
     // noinspection CssInvalidAtRule
-    @use 'FreeSerif';
+    @import'FreeSerif';
   } @else if unquote($font) == 'Source Sans Pro' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap';
   } @else if unquote($font) == 'Sorts Mill Goudy' {
     // noinspection CssInvalidAtRule
-    @use 'https://fonts.googleapis.com/css?family=Sorts+Mill+Goudy&display=swap';
+    @import'https://fonts.googleapis.com/css?family=Sorts+Mill+Goudy&display=swap';
   } @else if unquote($font) == 'New Athena Unicode' {
     // noinspection CssInvalidAtRule
-    @use 'NewAthenaUnicodeFont';
+    @import'NewAthenaUnicodeFont';
   }
 }
 

--- a/assets/book/typography/styles/_shapeshifter-font-stack-web.scss
+++ b/assets/book/typography/styles/_shapeshifter-font-stack-web.scss
@@ -14,65 +14,65 @@ $shapeshifter-fonts: ();
 @each $font in $shapeshifter-fonts {
   @if unquote($font) == 'Cormorant Garamond' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Cormorant+Garamond&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Cormorant+Garamond&display=swap';
   } @else if unquote($font) == 'Noto Serif' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Noto+Serif|Noto+Serif+JP|Noto+Serif+KR|Noto+Serif+SC|Noto+Serif+TC&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Noto+Serif|Noto+Serif+JP|Noto+Serif+KR|Noto+Serif+SC|Noto+Serif+TC&display=swap';
   } @else if unquote($font) == 'Spectral' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Spectral|Spectral+SC&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Spectral|Spectral+SC&display=swap';
   } @else if unquote($font) == 'Alegreya Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Alegreya|Alegreya+SC|Alegreya+Sans|Alegreya+Sans+SC&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Alegreya|Alegreya+SC|Alegreya+Sans|Alegreya+Sans+SC&display=swap';
   } @else if unquote($font) == 'Crimson Text' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Crimson+Text&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Crimson+Text&display=swap';
   } @else if unquote($font) == 'Roboto' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Roboto&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Roboto&display=swap';
   } @else if unquote($font) == 'Open Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Open+Sans&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Open+Sans&display=swap';
   } @else if unquote($font) == 'Lato' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Lato&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Lato&display=swap';
   } @else if unquote($font) == 'Montserrat' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Montserrat&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Montserrat&display=swap';
   } @else if unquote($font) == 'Raleway' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Raleway&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Raleway&display=swap';
   } @else if unquote($font) == 'Noto Sans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Noto+Sans|Noto+Sans+HK|Noto+Sans+JP|Noto+Sans+KR|Noto+Sans+SC|Noto+Sans+TC|Raleway&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Noto+Sans|Noto+Sans+HK|Noto+Sans+JP|Noto+Sans+KR|Noto+Sans+SC|Noto+Sans+TC|Raleway&display=swap';
   } @else if unquote($font) == 'Rubik' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Rubik&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Rubik&display=swap';
   } @else if unquote($font) == 'Barlow' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Barlow&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Barlow&display=swap';
     // noinspection CssInvalidAtRule
   } @else if unquote($font) == 'Libre Franklin' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Libre+Franklin&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Libre+Franklin&display=swap';
   } @else if unquote($font) == 'K2D' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=K2D&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=K2D&display=swap';
   } @else if unquote($font) == 'FreeSans' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'FreeSans';
+    @use 'FreeSans';
   } @else if unquote($font) == 'FreeSerif' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'FreeSerif';
+    @use 'FreeSerif';
   } @else if unquote($font) == 'Source Sans Pro' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap';
   } @else if unquote($font) == 'Sorts Mill Goudy' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'https://fonts.googleapis.com/css?family=Sorts+Mill+Goudy&display=swap';
+    @use 'https://fonts.googleapis.com/css?family=Sorts+Mill+Goudy&display=swap';
   } @else if unquote($font) == 'New Athena Unicode' {
     // noinspection CssInvalidAtRule
-    @scssphp-import-once 'NewAthenaUnicodeFont';
+    @use 'NewAthenaUnicodeFont';
   }
 }
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1071

This PR replaces the [deprecated](https://github.com/scssphp/scssphp/releases/tag/v1.5.0) `@scssphp-import` directive with`@import`. 

This removes [the deprecations warnings](https://github.com/pressbooks/pressbooks/actions/runs/3857997419/jobs/6576018337#step:9:24) in our tests.

### How to see that deprecation warnings are not being displayed during tests
- Install the test environment `lando install-tests`
- copy this version of the code in the temporary tests files:
  - Enter to the appserver container `lando ssh` 
  - Copy the pressbooks-book theme into tmp: `cp -R /app/web/app/themes/pressbooks-book/ /tmp/wordpress/wp-content/themes/`
- Run the tests in your pressbooks plugin folder `lando composer tests`
- Tests should not display warning deprecation notices.
