### PR TITLE
fix: transifex cmd path

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Install Transifex Client
         run: |
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
-          source ~/.bashrc
+        working-directory: /tmp
       - name: Pull translations from Transifex
-        run: tx pull --all --force --minimum-perc=25
+        run: /tmp/tx pull --all --force --minimum-perc=25
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
       - name: Setup PHP with tools


### PR DESCRIPTION
This PR fix the transifex command to run in the /tmp dir