### PR TITLE
fix: send export files event in google analytics v4

### DIFF
--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -70,7 +70,7 @@ use function \Pressbooks\Image\attachment_id_from_url;
 						// add_filter('pressbooks_download_tracking_code', function( $tracking, $filetype ) {
 						//  return "_gaq.push(['_trackEvent','exportFiles','Downloads','{$title}:{$filetype}']);";
 						// }, 10, 2); @codingStandardsIgnoreEnd
-						$tracking = apply_filters( 'pressbooks_download_tracking_code', "gtag( 'event','export_files', {action: 'download', title: '{$title}', file_type: '{$filetype}'});", $filetype, $title );
+						$tracking = apply_filters( 'pressbooks_download_tracking_code', "gtag( 'event','exportFiles', {action: 'download', title: '{$title}', file_type: '{$filetype}'});", $filetype, $title );
 						?>
 					<li class="dropdown-item">
 						<a rel="nofollow" onclick="<?php echo $tracking; ?>" itemprop="offers" itemscope itemtype="http://schema.org/Offer" href="<?php echo $url; ?>">

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -70,7 +70,7 @@ use function \Pressbooks\Image\attachment_id_from_url;
 						// add_filter('pressbooks_download_tracking_code', function( $tracking, $filetype ) {
 						//  return "_gaq.push(['_trackEvent','exportFiles','Downloads','{$title}:{$filetype}']);";
 						// }, 10, 2); @codingStandardsIgnoreEnd
-						$tracking = apply_filters( 'pressbooks_download_tracking_code', "ga('send','event','exportFiles','Downloads','{$title}:{$filetype}');", $filetype, $title );
+						$tracking = apply_filters( 'pressbooks_download_tracking_code', "gtag( 'event','export_files', {action: 'download', title: '{$title}', file_type: '{$filetype}'});", $filetype, $title );
 						?>
 					<li class="dropdown-item">
 						<a rel="nofollow" onclick="<?php echo $tracking; ?>" itemprop="offers" itemscope itemtype="http://schema.org/Offer" href="<?php echo $url; ?>">


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/3412

Related PR: https://github.com/pressbooks/pressbooks/pull/3428

This PR sends download events using Google Analytics 4.

### Testing case
- Ensure you have Google Analytics 4 ID configured correctly:
  - Go to Network Level > Settings > Google Analytics and make sure only 1 Google Analytics field is available to fill/update.
  - Add a Google ID. Ask the team for a test Google Analytics ID, and Google Analytics admin access to watch the real-time events.
- Go to a book page with exported files to be able to download any export from the home page.
- You should be able to watch the download event in real-time events in the Google Analytics admin platform.