### PR TITLE
chore: update bedrock trigger with environment variables

### DIFF
--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SQS_ARN_DEV: ${{ secrets.AWS_SQS_ARN_DEV }}
-          AWS_SQS_ARN_PROD: ${{ secrets.AWS_SQS_ARN_PROD }}
+          AWS_SNS_ARN_DEV: ${{ secrets.AWS_SNS_ARN_DEV }}
+          AWS_SNS_ARN_STAGING: ${{ secrets.AWS_SNS_ARN_STAGING }}
           INPUT_TRIGGERED_BY: ${{ github.repository }}
           INPUT_BRANCH: ${{ github.ref }}

--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -105,7 +105,10 @@ jobs:
       - name: Trigger Bedrock Update
         if: (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/production')  && matrix.experimental == false
         uses: pressbooks/composer-autoupdate-bedrock@main
-        with:
-          triggered-by: ${{ github.repository }}
-          token: ${{ secrets.PAT_COMPOSER_UPDATE }}
-          branch: ${{ github.ref }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SQS_ARN_DEV: ${{ secrets.AWS_SQS_ARN_DEV }}
+          AWS_SQS_ARN_PROD: ${{ secrets.AWS_SQS_ARN_PROD }}
+          INPUT_TRIGGERED_BY: ${{ github.repository }}
+          INPUT_BRANCH: ${{ github.ref }}


### PR DESCRIPTION
Resolves: pressbooks/private#1378
This PR updates the environment variables in the bedrock trigger step so it can send the repository details to the reusable workflow to send a message to the AWS SNS Topic.