### PR TITLE
fix: filter lang map

### DIFF
--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         php: [ 8.1, 8.2 ]
         os: [ ubuntu-20.04 ]
-        wordpress: [ 6.4.3, latest ]
+        wordpress: [ '6.5', latest ]
         include:
           - experimental: true
           - experimental: false
             php: 8.1
-            wordpress: 6.4.3
+            wordpress: '6.5'
 
     name: Test - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
 

--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:pressbooks:p:pressbooks-book:r:pressbooks-book]
-file_filter = languages/pressbooks-book-<lang>.po
+file_filter = languages/<lang>.po
 lang_map = de:de_DE, es:es_ES, fr:fr_FR, gl:gl_ES, nb:nb_NO, it:it_IT, ka:ka_GE, ru:ru_RU, ta:ta_LK, pa:pa_IN, hr_HR:hr
 source_file = languages/pressbooks-book.pot
 source_lang = en

--- a/.tx/transifex.yaml
+++ b/.tx/transifex.yaml
@@ -4,7 +4,7 @@ git:
           file_format: PO
           source_file: languages/pressbooks-book.pot
           source_language: en
-          translation_files_expression: languages/pressbooks-book-<lang>.po
+          translation_files_expression: languages/<lang>.po
     settings:
         pr_branch_name: chore/update-translations-<br_unique_id>
         language_mapping:


### PR DESCRIPTION
### Problem

* Transifex translations are not working as expected, we introduced a change https://github.com/pressbooks/pressbooks-book/pull/1190/files to try to setup automated github sync with transifex but we are dealing with some issues regarding duplicate translation resources and missing translations.

Translation files filenames

** Before **
```
languages/es_ES.mo
```

**Now**
```
languages/pressbooks-book-es_ES.mo
```

### Solution

* Revert the translation prefix change because the old translations on this plugin are not using a prefix like pressbooks does, you can look at previous commits files doesn't contains a prefix

** After this change **
```
languages/es_ES.mo
```