### PR TITLE
fix: add publisher city to metadata block

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -492,6 +492,7 @@ function get_metakeys(): array {
 		'pb_additional_subjects' => __( 'Additional Subject(s)', 'pressbooks-book' ),
 		'pb_institutions' => _n_noop( 'Institution', 'Institutions', 'pressbooks-book' ),
 		'pb_publisher' => __( 'Publisher', 'pressbooks-book' ),
+		'pb_publisher_city' => __( 'Publisher City', 'pressbooks-book' ),
 		'pb_publication_date' => __( 'Publication Date', 'pressbooks-book' ),
 		'pb_book_doi' => __( 'Digital Object Identifier (DOI)', 'pressbooks-book' ),
 		'pb_ebook_isbn' => __( 'Ebook ISBN', 'pressbooks-book' ),


### PR DESCRIPTION
Display Publisher city in metadata section of book homepage when set. Fix for #1299. 

To test:
1. Add a publisher city to a book's book info
2. Visit the book homepage and observe that publisher city does not appear in the metadata section
3. Check out this branch
4. Visit the book homepage. Observe that publisher city does appear in the metadata section, just after 'Publisher'
![Screenshot 2025-01-03 101744](https://github.com/user-attachments/assets/433d1121-952d-4569-8845-6177f64bee70)
