### PR TITLE
fix: add role presentation to license icon in the book home page

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -110,19 +110,22 @@ function license_to_icons( $license ) {
 	if ( ! $license ) {
 		return '';
 	}
+
 	$output = '';
+	$svg_tag = '<svg class="icon" style="fill: currentColor" role="presentation"><use href="#%s" /></svg>';
+
 	if ( strpos( $license, 'cc' ) !== false && $license !== 'cc-zero' ) {
 		$parts = explode( '-', $license );
 		foreach ( $parts as $part ) {
 			if ( $part !== 'cc' ) {
 				$part = 'cc-' . $part;
 			}
-			$output .= sprintf( '<svg class="icon" style="fill: currentColor"><use href="#%s" /></svg>', $part );
+			$output .= sprintf( $svg_tag, $part );
 		}
 	} elseif ( $license === 'cc-zero' ) {
-		$output .= '<svg class="icon" style="fill: currentColor"><use href="#cc-zero" /></svg>';
+		$output .= sprintf( $svg_tag, 'cc-zero' );
 	} elseif ( $license === 'public-domain' ) {
-		$output .= '<svg class="icon" style="fill: currentColor"><use href="#cc-pd" /></svg>';
+		$output .= sprintf( $svg_tag, 'cc-pd' );
 	} elseif ( $license === 'all-rights-reserved' ) {
 		return '';
 	}

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -47,11 +47,11 @@ class HelpersTest extends WP_UnitTestCase {
 
 	function test_license_to_icons() {
 		$output = license_to_icons( 'cc-by' );
-		$this->assertEquals( '<svg class="icon" style="fill: currentColor"><use href="#cc" /></svg><svg class="icon" style="fill: currentColor"><use href="#cc-by" /></svg>', $output );
+		$this->assertEquals( '<svg class="icon" style="fill: currentColor" role="presentation"><use href="#cc" /></svg><svg class="icon" style="fill: currentColor" role="presentation"><use href="#cc-by" /></svg>', $output );
 		$output = license_to_icons( 'public-domain' );
-		$this->assertEquals( '<svg class="icon" style="fill: currentColor"><use href="#cc-pd" /></svg>', $output );
+		$this->assertEquals( '<svg class="icon" style="fill: currentColor" role="presentation"><use href="#cc-pd" /></svg>', $output );
 		$output = license_to_icons( 'cc-zero' );
-		$this->assertEquals( '<svg class="icon" style="fill: currentColor"><use href="#cc-zero" /></svg>', $output );
+		$this->assertEquals( '<svg class="icon" style="fill: currentColor" role="presentation"><use href="#cc-zero" /></svg>', $output );
 		$output = license_to_icons( 'all-rights-reserved' );
 		$this->assertEquals( '', $output );
 		$output = license_to_icons( 'foo' );


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1579

This pull request includes a small but important change to the `license_to_icons` function in the `inc/helpers/namespace.php` file. The change introduces a new variable to streamline the creation of SVG tags, making the code more maintainable and reducing redundancy.

Codebase simplification:

* [`inc/helpers/namespace.php`](diffhunk://#diff-f93d7f87d15ccbc7a4cc1b695d2fe172b6b705d3c4edce105dbc6bf93672559bR113-R128): Introduced the `$svg_tag` variable to store the SVG template and replaced repeated `sprintf` calls with this variable for generating SVG icons.

### Testing
- Pick a book and edit its license with a one that is rendered with icons, like the C0 one for example.
- Go to a book home page
- Check the license icon rendered just at the left of the book cover. It should contain the `role="presentation"` attribute in its DOM.