### PR TITLE
fix: replace guides and tutorials link with user guide

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -67,7 +67,7 @@ if ( $contact_link ) {
 				<?php /* translators: %s: Pressbooks */ ?>
 				<p class="footer__pressbooks__links__title"><a href="https://pressbooks.com"><?php printf( __( 'Powered by %s', 'pressbooks-book' ), '<span class="pressbooks">Pressbooks</span>' ); ?></a></p>
 				<ul class="footer__pressbooks__links__list">
-					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-guide-tutorials"><a href="https://pressbooks.com/support/"><?php _e( 'Guides and Tutorials', 'pressbooks-book' ); ?></a></li>
+                    <li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-guide"><a href="https://guide.pressbooks.com"><?php _e( 'Pressbooks User Guide', 'pressbooks-aldine' ); ?></a></li>
 					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-pressbooks-directory">|<a href="https://pressbooks.directory"><?php _e( 'Pressbooks Directory', 'pressbooks-book' ); ?></a></li>
 					<?php if ( $contact_link ) : ?>
 						<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-contact">|<a href="<?php echo $contact_link; ?>"><?php _e( 'Contact', 'pressbooks-book' ); ?></a></li>

--- a/footer.php
+++ b/footer.php
@@ -67,7 +67,7 @@ if ( $contact_link ) {
 				<?php /* translators: %s: Pressbooks */ ?>
 				<p class="footer__pressbooks__links__title"><a href="https://pressbooks.com"><?php printf( __( 'Powered by %s', 'pressbooks-book' ), '<span class="pressbooks">Pressbooks</span>' ); ?></a></p>
 				<ul class="footer__pressbooks__links__list">
-					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-guide"><a href="https://guide.pressbooks.com"><?php _e( 'Pressbooks User Guide', 'pressbooks-aldine' ); ?></a></li>
+					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-guide"><a href="https://guide.pressbooks.com"><?php _e( 'Pressbooks User Guide', 'pressbooks-book' ); ?></a></li>
 					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-pressbooks-directory">|<a href="https://pressbooks.directory"><?php _e( 'Pressbooks Directory', 'pressbooks-book' ); ?></a></li>
 					<?php if ( $contact_link ) : ?>
 						<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-contact">|<a href="<?php echo $contact_link; ?>"><?php _e( 'Contact', 'pressbooks-book' ); ?></a></li>

--- a/footer.php
+++ b/footer.php
@@ -67,7 +67,7 @@ if ( $contact_link ) {
 				<?php /* translators: %s: Pressbooks */ ?>
 				<p class="footer__pressbooks__links__title"><a href="https://pressbooks.com"><?php printf( __( 'Powered by %s', 'pressbooks-book' ), '<span class="pressbooks">Pressbooks</span>' ); ?></a></p>
 				<ul class="footer__pressbooks__links__list">
-                    <li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-guide"><a href="https://guide.pressbooks.com"><?php _e( 'Pressbooks User Guide', 'pressbooks-aldine' ); ?></a></li>
+					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-guide"><a href="https://guide.pressbooks.com"><?php _e( 'Pressbooks User Guide', 'pressbooks-aldine' ); ?></a></li>
 					<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-pressbooks-directory">|<a href="https://pressbooks.directory"><?php _e( 'Pressbooks Directory', 'pressbooks-book' ); ?></a></li>
 					<?php if ( $contact_link ) : ?>
 						<li class="footer__pressbooks__links__list-item footer__pressbooks__links__list-item-contact">|<a href="<?php echo $contact_link; ?>"><?php _e( 'Contact', 'pressbooks-book' ); ?></a></li>


### PR DESCRIPTION
Replace guides and tuturials link that points to marketing site with direct link to Pressbooks User guide in footer. Partial fix for https://github.com/pressbooks/private/issues/1721. Accompanies https://github.com/pressbooks/pressbooks/pull/4030 and https://github.com/pressbooks/pressbooks-aldine/pull/493