### PR TITLE
fix: display only editors or authors

### DIFF
--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -16,7 +16,7 @@ use function \Pressbooks\Image\attachment_id_from_url;
 		<?php if ( ! empty( $book_information['pb_authors'] ) ) { ?>
 			<p class="book-header__author"><span class="screen-reader-text"><?php echo translate_nooped_plural( _n_noop( 'Author', 'Authors', 'pressbooks-book' ), \PressbooksBook\Helpers\count_items( $book_information['pb_authors'] ), 'pressbooks-book' ); ?>: </span><?php echo $book_information['pb_authors']; ?></p>
 		<?php } ?>
-		<?php if ( ! empty( $book_information['pb_editors'] ) ) { ?>
+		<?php if ( empty( $book_information['pb_authors'] ) && ! empty( $book_information['pb_editors'] ) ) { ?>
 			<p class="book-header__contributor"><?php _e( 'Edited by ', 'pressbooks-book' ); ?> <?php echo $book_information['pb_editors']; ?></p>
 		<?php } ?>
 		<div class="book-header__cover">

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -19,12 +19,6 @@ use function \Pressbooks\Image\attachment_id_from_url;
 		<?php if ( ! empty( $book_information['pb_editors'] ) ) { ?>
 			<p class="book-header__contributor"><?php _e( 'Edited by ', 'pressbooks-book' ); ?> <?php echo $book_information['pb_editors']; ?></p>
 		<?php } ?>
-		<?php if ( ! empty( $book_information['pb_translators'] ) ) { ?>
-			<p class="book-header__contributor"><?php _e( 'Translated by ', 'pressbooks-book' ); ?> <?php echo $book_information['pb_translators']; ?></p>
-		<?php } ?>
-		<?php if ( ! empty( $book_information['pb_illustrators'] ) ) { ?>
-			<p class="book-header__contributor"><?php _e( 'Illustrated by ', 'pressbooks-book' ); ?> <?php echo $book_information['pb_illustrators']; ?></p>
-		<?php } ?>
 		<div class="book-header__cover">
 			<?php if ( ! empty( $book_information['pb_cover_image'] ) ) { ?>
 				<div class="book-header__cover__image">


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1749

This pull request simplifies the `partials/content-cover-book-header.php` file by removing redundant sections of code related to displaying translators and illustrators in the book header. 

Related PR: https://github.com/pressbooks/pressbooks/pull/4067

Code simplification:

* Removed conditional blocks that displayed translators (`pb_translators`) and illustrators (`pb_illustrators`) from the book header, leaving only the editors (`pb_editors`) section. This reduces complexity and focuses the header content.