### PR TITLE
fix: display series title and number on book homepage

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -494,6 +494,8 @@ function get_metakeys(): array {
 		'pb_primary_subject' => __( 'Primary Subject', 'pressbooks-book' ),
 		'pb_additional_subjects' => __( 'Additional Subject(s)', 'pressbooks-book' ),
 		'pb_institutions' => _n_noop( 'Institution', 'Institutions', 'pressbooks-book' ),
+		'pb_series_title' => __( 'Series Title', 'pressbooks-book' ),
+		'pb_series_number' => __( 'Series Number', 'pressbooks-book' ),
 		'pb_publisher' => __( 'Publisher', 'pressbooks-book' ),
 		'pb_publisher_city' => __( 'Publisher City', 'pressbooks-book' ),
 		'pb_publication_date' => __( 'Publication Date', 'pressbooks-book' ),


### PR DESCRIPTION
Display book series title and number in metadata block on homepage. Fix for https://github.com/pressbooks/pressbooks-book/issues/1337

To test:
1. Go to book info and click 'Show additional information'
2. Add a Series Title and Series Number and save
3. Visit book homepage and observe that these are now displayed in the metadata block

![Screenshot 2025-06-05 191729](https://github.com/user-attachments/assets/7604a4ea-825f-4ad1-b6b9-99c9899f2c1c)
