### PR TITLE
chore: update update-pot.yml

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -9,13 +9,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  jobs:
-    update-pot-file:
-      uses: pressbooks/reusable-workflows/.github/workflows/update-pot.yml@main
-      secrets: inherit
-      with:
-        domain: 'pressbooks-book'
-        slug: 'pressbooks-book'
-        package_name: 'McLuhan'
-        headers: '{"Report-Msgid-Bugs-To": "https://github.com/pressbooks/pressbooks-book/issues"}'
-        pull_request_number: ${{ github.event.pull_request.number }}
+  update-pot-file:
+    uses: pressbooks/reusable-workflows/.github/workflows/update-pot.yml@main
+    secrets: inherit
+    with:
+      domain: 'pressbooks-book'
+      slug: 'pressbooks-book'
+      package_name: 'McLuhan'
+      headers: '{"Report-Msgid-Bugs-To": "https://github.com/pressbooks/pressbooks-book/issues"}'
+      pull_request_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.github/workflows/update-pot.yml` file by removing an unnecessary duplicate `jobs:` key, ensuring the YAML structure is cleaner and more accurate.