### PR TITLE
fix: add titles to SVGs in footer and reading interface

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -71,13 +71,13 @@ if ( $contact_link ) {
 			</div>
 			<div class="footer__pressbooks__social">
 				<a class="youtube" href="https://www.youtube.com/user/pressbooks" title="<?php _e( 'Pressbooks on YouTube', 'pressbooks-book' ); ?>">
-					<svg class="icon--svg">
+					<svg class="icon--svg" title="YouTube logo">
 						<use href="#youtube-icon" />
 					</svg>
 					<span class="screen-reader-text"><?php _e( 'Pressbooks on YouTube', 'pressbooks-book' ); ?></span>
 				</a>
 				<a class="linkedin" href="https://www.linkedin.com/company/pressbooks/?originalSubdomain=ca" title="<?php _e( 'Pressbooks on LinkedIn', 'pressbooks-book' ); ?>">
-					<svg class="icon--svg">
+					<svg class="icon--svg" title="LinkedIn logo">
 						<use href="#linkedin-icon" />
 					</svg>
 					<span class="screen-reader-text"><?php _e( 'Pressbooks on LinkedIn', 'pressbooks-aldine' ); ?></span></a>

--- a/footer.php
+++ b/footer.php
@@ -54,12 +54,7 @@ if ( $contact_link ) {
 	<div class="footer__inner">
 		<section class="footer__pressbooks">
 			<a class="footer__pressbooks__icon" href="https://pressbooks.com" title="Pressbooks">
-				<svg class="icon--svg" role="img" aria-label="
-				<?php
-				/* translators: %s: name of network */
-							printf( __( 'Logo for %s', 'pressbooks-book' ), 'Pressbooks' );
-				?>
-							">
+				<svg class="icon--svg" role="img" title="Pressbooks logo" aria-label="Pressbooks logo">
 					<use href="#icon-pressbooks" />
 				</svg>
 			</a>

--- a/footer.php
+++ b/footer.php
@@ -55,6 +55,7 @@ if ( $contact_link ) {
 		<section class="footer__pressbooks">
 			<a class="footer__pressbooks__icon" href="https://pressbooks.com" title="Pressbooks">
 				<svg class="icon--svg" role="img" title="Pressbooks logo" aria-label="Pressbooks logo">
+					<title><?php echo esc_html__( 'Pressbooks logo', 'pressbooks-aldine' ); ?></title>
 					<use href="#icon-pressbooks" />
 				</svg>
 			</a>
@@ -71,13 +72,15 @@ if ( $contact_link ) {
 			</div>
 			<div class="footer__pressbooks__social">
 				<a class="youtube" href="https://www.youtube.com/user/pressbooks" title="<?php _e( 'Pressbooks on YouTube', 'pressbooks-book' ); ?>">
-					<svg class="icon--svg" title="YouTube logo">
+					<svg class="icon--svg">
+						<title><?php echo esc_html__( 'YouTube logo', 'pressbooks-aldine' ); ?></title>
 						<use href="#youtube-icon" />
 					</svg>
 					<span class="screen-reader-text"><?php _e( 'Pressbooks on YouTube', 'pressbooks-book' ); ?></span>
 				</a>
 				<a class="linkedin" href="https://www.linkedin.com/company/pressbooks/?originalSubdomain=ca" title="<?php _e( 'Pressbooks on LinkedIn', 'pressbooks-book' ); ?>">
-					<svg class="icon--svg" title="LinkedIn logo">
+					<svg class="icon--svg">
+						<title><?php echo esc_html__( 'LinkedIn logo', 'pressbooks-aldine' ); ?></title>
 						<use href="#linkedin-icon" />
 					</svg>
 					<span class="screen-reader-text"><?php _e( 'Pressbooks on LinkedIn', 'pressbooks-aldine' ); ?></span></a>

--- a/footer.php
+++ b/footer.php
@@ -53,11 +53,11 @@ if ( $contact_link ) {
 ">
 	<div class="footer__inner">
 		<section class="footer__pressbooks">
-			<a class="footer__pressbooks__icon" href="https://pressbooks.com" title="Pressbooks">
-				<svg class="icon--svg" role="img" aria-label="<?php echo esc_html__( 'Pressbooks logo', 'pressbooks-aldine' ); ?>">
-					<title><?php echo esc_html__( 'Pressbooks logo', 'pressbooks-aldine' ); ?></title>
+			<a class="footer__pressbooks__icon" href="https://pressbooks.com">
+				<svg class="icon--svg" role="none" aria-hidden="true" focusable="false">
 					<use href="#icon-pressbooks" />
 				</svg>
+                <span class="screen-reader-text"><?php _e( 'Pressbooks', 'pressbooks-book' ); ?></span>
 			</a>
 			<div class="footer__pressbooks__links">
 				<?php /* translators: %s: Pressbooks */ ?>
@@ -71,16 +71,14 @@ if ( $contact_link ) {
 				</ul>
 			</div>
 			<div class="footer__pressbooks__social">
-				<a class="youtube" href="https://www.youtube.com/user/pressbooks" title="<?php _e( 'Pressbooks on YouTube', 'pressbooks-book' ); ?>">
-					<svg class="icon--svg">
-						<title><?php echo esc_html__( 'YouTube logo', 'pressbooks-aldine' ); ?></title>
-						<use href="#youtube-icon" />
+				<a class="youtube" href="https://www.youtube.com/user/pressbooks">
+					<svg class="icon--svg" role="none" aria-hidden="true" focusable="false">
+                        <use href="#youtube-icon" />
 					</svg>
 					<span class="screen-reader-text"><?php _e( 'Pressbooks on YouTube', 'pressbooks-book' ); ?></span>
 				</a>
-				<a class="linkedin" href="https://www.linkedin.com/company/pressbooks/?originalSubdomain=ca" title="<?php _e( 'Pressbooks on LinkedIn', 'pressbooks-book' ); ?>">
-					<svg class="icon--svg">
-						<title><?php echo esc_html__( 'LinkedIn logo', 'pressbooks-aldine' ); ?></title>
+				<a class="linkedin" href="https://www.linkedin.com/company/pressbooks/?originalSubdomain=ca">
+					<svg class="icon--svg" role="none" aria-hidden="true" focusable="false">
 						<use href="#linkedin-icon" />
 					</svg>
 					<span class="screen-reader-text"><?php _e( 'Pressbooks on LinkedIn', 'pressbooks-aldine' ); ?></span></a>

--- a/footer.php
+++ b/footer.php
@@ -57,7 +57,7 @@ if ( $contact_link ) {
 				<svg class="icon--svg" role="none" aria-hidden="true" focusable="false">
 					<use href="#icon-pressbooks" />
 				</svg>
-                <span class="screen-reader-text"><?php _e( 'Pressbooks', 'pressbooks-book' ); ?></span>
+				<span class="screen-reader-text"><?php _e( 'Pressbooks', 'pressbooks-book' ); ?></span>
 			</a>
 			<div class="footer__pressbooks__links">
 				<?php /* translators: %s: Pressbooks */ ?>
@@ -73,7 +73,7 @@ if ( $contact_link ) {
 			<div class="footer__pressbooks__social">
 				<a class="youtube" href="https://www.youtube.com/user/pressbooks">
 					<svg class="icon--svg" role="none" aria-hidden="true" focusable="false">
-                        <use href="#youtube-icon" />
+						<use href="#youtube-icon" />
 					</svg>
 					<span class="screen-reader-text"><?php _e( 'Pressbooks on YouTube', 'pressbooks-book' ); ?></span>
 				</a>

--- a/footer.php
+++ b/footer.php
@@ -54,7 +54,7 @@ if ( $contact_link ) {
 	<div class="footer__inner">
 		<section class="footer__pressbooks">
 			<a class="footer__pressbooks__icon" href="https://pressbooks.com" title="Pressbooks">
-				<svg class="icon--svg" role="img" title="Pressbooks logo" aria-label="Pressbooks logo">
+				<svg class="icon--svg" role="img" aria-label="<?php echo esc_html__( 'Pressbooks logo', 'pressbooks-aldine' ); ?>">
 					<title><?php echo esc_html__( 'Pressbooks logo', 'pressbooks-aldine' ); ?></title>
 					<use href="#icon-pressbooks" />
 				</svg>

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -538,7 +538,7 @@ function get_links( $echo = true ) {
 			<?php if ( $prev_chapter !== '/' ) { ?>
 				<?php /* translators: %s: post title */ ?>
 				<a href="<?php echo $prev_chapter; ?>" title="<?php printf( __( 'Previous: %s', 'pressbooks-book' ), $prev_title ); ?>">
-					<svg class="icon--svg"><use href="#arrow-left" /></svg>
+					<svg class="icon--svg" title="Previous"><use href="#arrow-left" /></svg>
 					<?php /* translators: %s: post short title or title */ ?>
 					<?php printf( __( 'Previous: %s', 'pressbooks-book' ), $prev_label ); ?>
 				</a>
@@ -550,7 +550,7 @@ function get_links( $echo = true ) {
 				<a href="<?php echo $next_chapter ?>" title="<?php printf( __( 'Next: %s', 'pressbooks-book' ), $next_title ); ?>">
 					<?php /* translators: %s: post short title or title */ ?>
 					<?php printf( __( 'Next: %s', 'pressbooks-book' ), $next_label ); ?>
-					<svg class="icon--svg"><use href="#arrow-right" /></svg>
+					<svg class="icon--svg" title="Next"><use href="#arrow-right" /></svg>
 				</a>
 			<?php endif; ?>
 		</div>

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -550,7 +550,7 @@ function get_links( $echo = true ) {
 				<a href="<?php echo $next_chapter ?>">
 					<?php /* translators: %s: post short title or title */ ?>
 					<?php printf( __( 'Next: %s', 'pressbooks-book' ), $next_label ); ?>
-					<svg class="icon--svg" role="none" aria-hidden="true" focusable="false"><use href="#arrow-left"><use href="#arrow-right" /></svg>
+					<svg class="icon--svg" role="none" aria-hidden="true" focusable="false"><use href="#arrow-right" /></svg>
 				</a>
 			<?php endif; ?>
 		</div>

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -537,8 +537,8 @@ function get_links( $echo = true ) {
 		<div class="nav-reading__previous js-nav-previous">
 			<?php if ( $prev_chapter !== '/' ) { ?>
 				<?php /* translators: %s: post title */ ?>
-				<a href="<?php echo $prev_chapter; ?>" title="<?php printf( __( 'Previous: %s', 'pressbooks-book' ), $prev_title ); ?>">
-					<svg class="icon--svg"><title><?php echo esc_html__( 'Previous', 'pressbooks-book' ); ?></title><use href="#arrow-left" /></svg>
+				<a href="<?php echo $prev_chapter; ?>">
+					<svg class="icon--svg" role="none" aria-hidden="true" focusable="false"><use href="#arrow-left" /></svg>
 					<?php /* translators: %s: post short title or title */ ?>
 					<?php printf( __( 'Previous: %s', 'pressbooks-book' ), $prev_label ); ?>
 				</a>
@@ -547,10 +547,10 @@ function get_links( $echo = true ) {
 		<div class="nav-reading__next js-nav-next">
 			<?php if ( $next_chapter !== '/' ) : ?>
 				<?php /* translators: %s: post title, */ ?>
-				<a href="<?php echo $next_chapter ?>" title="<?php printf( __( 'Next: %s', 'pressbooks-book' ), $next_title ); ?>">
+				<a href="<?php echo $next_chapter ?>">
 					<?php /* translators: %s: post short title or title */ ?>
 					<?php printf( __( 'Next: %s', 'pressbooks-book' ), $next_label ); ?>
-					<svg class="icon--svg"><title><?php echo esc_html__( 'Next', 'pressbooks-book' ); ?></title><use href="#arrow-right" /></svg>
+					<svg class="icon--svg" role="none" aria-hidden="true" focusable="false"><use href="#arrow-left"><use href="#arrow-right" /></svg>
 				</a>
 			<?php endif; ?>
 		</div>

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -538,7 +538,7 @@ function get_links( $echo = true ) {
 			<?php if ( $prev_chapter !== '/' ) { ?>
 				<?php /* translators: %s: post title */ ?>
 				<a href="<?php echo $prev_chapter; ?>" title="<?php printf( __( 'Previous: %s', 'pressbooks-book' ), $prev_title ); ?>">
-					<svg class="icon--svg" title="Previous"><use href="#arrow-left" /></svg>
+					<svg class="icon--svg"><title><?php echo esc_html__( 'Previous', 'pressbooks-book' ); ?></title><use href="#arrow-left" /></svg>
 					<?php /* translators: %s: post short title or title */ ?>
 					<?php printf( __( 'Previous: %s', 'pressbooks-book' ), $prev_label ); ?>
 				</a>
@@ -550,7 +550,7 @@ function get_links( $echo = true ) {
 				<a href="<?php echo $next_chapter ?>" title="<?php printf( __( 'Next: %s', 'pressbooks-book' ), $next_title ); ?>">
 					<?php /* translators: %s: post short title or title */ ?>
 					<?php printf( __( 'Next: %s', 'pressbooks-book' ), $next_label ); ?>
-					<svg class="icon--svg" title="Next"><use href="#arrow-right" /></svg>
+					<svg class="icon--svg"><title><?php echo esc_html__( 'Next', 'pressbooks-book' ); ?></title><use href="#arrow-right" /></svg>
 				</a>
 			<?php endif; ?>
 		</div>


### PR DESCRIPTION
Add titles to SVGs to make them more accessible to screenreaders. Partial fix for https://github.com/pressbooks/pressbooks-book/issues/617