### PR TITLE
fix: sanitize page buy URLs rendering

### DIFF
--- a/page-buy.php
+++ b/page-buy.php
@@ -22,7 +22,7 @@ get_header(); ?>
 					<ul class="buy-book">
 						<?php if ( isset( $urls['amazon'] ) && $urls['amazon'] ) : ?>
 							<?php /* translators: %1$s: url to purchase */ ?>
-						<li class="buy-amazon"><a href="<?php print $urls['amazon']; ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/amazon.png" width="100" height="20" alt="
+						<li class="buy-amazon"><a href="<?php echo esc_url( $urls['amazon'] ); ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/amazon.png" width="100" height="20" alt="
 							<?php
 							/* translators: %s: name of organization */
 							printf( __( 'Logo for %s', 'pressbooks-book' ), 'Amazon' );
@@ -32,7 +32,7 @@ get_header(); ?>
 
 						<?php if ( isset( $urls['oreilly'] ) && $urls['oreilly'] ) : ?>
 							<?php /* translators: %1$s: url to purchase */ ?>
-						<li class="buy-oreilly"><a href="<?php print $urls['oreilly']; ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/oreilly.png" width="100" height="18" alt="
+						<li class="buy-oreilly"><a href="<?php echo esc_url( $urls['oreilly'] ); ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/oreilly.png" width="100" height="18" alt="
 							<?php
 							/* translators: %s: name of organization */
 							printf( __( 'Logo for %s', 'pressbooks-book' ), 'O’Reilly' );
@@ -42,7 +42,7 @@ get_header(); ?>
 
 						<?php if ( isset( $urls['barnesandnoble'] ) && $urls['barnesandnoble'] ) : ?>
 							<?php /* translators: %1$s: url to purchase */ ?>
-						<li class="buy-barnes-and-noble"><a href="<?php print $urls['barnesandnoble']; ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/barnes-and-noble.png" width="100" height="16" alt="
+						<li class="buy-barnes-and-noble"><a href="<?php echo esc_url( $urls['barnesandnoble'] ); ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/barnes-and-noble.png" width="100" height="16" alt="
 							<?php
 							/* translators: %s: name of organization */
 							printf( __( 'Logo for %s', 'pressbooks-book' ), 'Barnes &amp; Noble' );
@@ -52,7 +52,7 @@ get_header(); ?>
 
 						<?php if ( isset( $urls['kobo'] ) && $urls['kobo'] ) : ?>
 							<?php /* translators: %1$s: url to purchase */ ?>
-						<li class="buy-kobo"><a href="<?php print $urls['kobo']; ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/kobo.png" width="54" height="29" alt="
+						<li class="buy-kobo"><a href="<?php echo esc_url( $urls['kobo'] ); ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/kobo.png" width="54" height="29" alt="
 							<?php
 							/* translators: %s: name of organization */
 							printf( __( 'Logo for %s', 'pressbooks-book' ), 'Kobo' );
@@ -62,7 +62,7 @@ get_header(); ?>
 
 						<?php if ( isset( $urls['applebooks'] ) && $urls['applebooks'] ) : ?>
 							<?php /* translators: %1$s: url to purchase */ ?>
-						<li class="buy-applebooks"><a href="<?php print $urls['applebooks']; ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/ibooks.png" width="34" height="34" alt="
+						<li class="buy-applebooks"><a href="<?php echo esc_url( $urls['applebooks'] ); ?>" class="bookstore-logo-link logo"><img src="<?php bloginfo( 'template_directory' ); ?>/dist/images/ibooks.png" width="34" height="34" alt="
 							<?php
 							/* translators: %s: name of organization */
 							printf( __( 'Logo for %s', 'pressbooks-book' ), 'iBooks' );
@@ -71,7 +71,7 @@ get_header(); ?>
 					<?php endif; ?>
 						<?php if ( isset( $urls['otherservice'] ) && $urls['otherservice'] ) : ?>
 							<?php /* translators: %1$s: url to purchase */ ?>
-						<li class="buy-other"><?php _e( 'Purchase here:', 'pressbooks-book' ); ?> <a href="<?php print $urls['otherservice']; ?>"><?php print $urls['otherservice']; ?></a></li>
+						<li class="buy-other"><?php _e( 'Purchase here:', 'pressbooks-book' ); ?> <a href="<?php echo esc_url( $urls['otherservice'] ); ?>"><?php echo esc_url( $urls['otherservice'] ); ?></a></li>
 						<?php endif; ?>
 						</ul>
 				<?php endif; ?>


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1781

For testing notes, see: https://github.com/pressbooks/pressbooks/pull/4129

This pull request updates the `page-buy.php` file to improve security by replacing instances of `print` with `esc_url` for sanitizing URLs. This ensures that all URLs are properly escaped before being output to the browser, reducing the risk of XSS vulnerabilities.

### Security improvements:

* Replaced `print` with `esc_url` for the Amazon purchase link to sanitize the URL. (`[page-buy.phpL25-R25](diffhunk://#diff-4691cfd35cc1b6d76e887261b178dc362f4fb95e3216dff8eb0bb5106eea361aL25-R25)`)
* Replaced `print` with `esc_url` for the O'Reilly purchase link to sanitize the URL. (`[page-buy.phpL35-R35](diffhunk://#diff-4691cfd35cc1b6d76e887261b178dc362f4fb95e3216dff8eb0bb5106eea361aL35-R35)`)
* Replaced `print` with `esc_url` for the Barnes & Noble purchase link to sanitize the URL. (`[page-buy.phpL45-R45](diffhunk://#diff-4691cfd35cc1b6d76e887261b178dc362f4fb95e3216dff8eb0bb5106eea361aL45-R45)`)
* Replaced `print` with `esc_url` for the Kobo purchase link to sanitize the URL. (`[page-buy.phpL55-R55](diffhunk://#diff-4691cfd35cc1b6d76e887261b178dc362f4fb95e3216dff8eb0bb5106eea361aL55-R55)`)
* Replaced `print` with `esc_url` for the Apple Books purchase link to sanitize the URL. (`[page-buy.phpL65-R65](diffhunk://#diff-4691cfd35cc1b6d76e887261b178dc362f4fb95e3216dff8eb0bb5106eea361aL65-R65)`)
* Updated the "other service" purchase link to use `esc_url` for both the anchor tag's `href` and the displayed URL. (`[page-buy.phpL74-R74](diffhunk://#diff-4691cfd35cc1b6d76e887261b178dc362f4fb95e3216dff8eb0bb5106eea361aL74-R74)`)