### PR TITLE
fix: escape DOI url

### DIFF
--- a/partials/content-cover-metadata.php
+++ b/partials/content-cover-metadata.php
@@ -42,7 +42,7 @@
 								 * @since Pressbooks @ 5.6.0
 								 */
 								$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://doi.org' );
-								$book_information[ $key ] = sprintf( '<a itemprop="sameAs" href="%1$s">%1$s</a>', trailingslashit( $doi_resolver ) . $book_information[ $key ] );
+								$book_information[ $key ] = sprintf( '<a itemprop="sameAs" href="%1$s">%1$s</a>', esc_url( trailingslashit( $doi_resolver ) . $book_information[ $key ] ) );
 							}
 								echo $book_information[ $key ];
 							?>

--- a/single.php
+++ b/single.php
@@ -47,7 +47,7 @@
 									 * @since Pressbooks @ 5.6.0
 									 */
 									$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://doi.org' );
-									printf( '<a itemprop="sameAs" href="%1$s">%1$s</a>', trailingslashit( $doi_resolver ) . $pb_section_doi );
+									printf( '<a itemprop="sameAs" href="%1$s">%1$s</a>', esc_url( trailingslashit( $doi_resolver ) . $pb_section_doi ) );
 									?>
 									</p>
 								<?php } ?>


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1782

This pull request focuses on improving security by ensuring proper URL sanitization in two files. The changes involve wrapping dynamically generated URLs with the `esc_url` function to prevent potential vulnerabilities.

### Security Improvements:

* [`partials/content-cover-metadata.php`](diffhunk://#diff-f8ced3a73e84d8d4e42c003cba969f977ae163f9a53c1eac9708ff787525134cL45-R45): Updated the `$book_information` URL generation to use `esc_url` for sanitizing the dynamically constructed URL.
* [`single.php`](diffhunk://#diff-8e039a17b2aadb723e862bced701672b6e20a79e19ca6426b49084fc76d52624L50-R50): Modified the `printf` statement to sanitize the `$pb_section_doi` URL with `esc_url` before outputting it.

### Testing notes
To replicate the vulnerability in the `dev` branch:
- Go to a book dashboard and in the Book Info section store something like `Title" onmouseover="alert('XSS')` in the DOI field.
- Go to the book home page (Metadata Section below) and mouse over the DOI, you will see the JS injected.

In this branch, you shouldn't be able to execute injected JS.