### PR TITLE
fix: reduce bot downloads

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -71,6 +71,7 @@ add_filter( 'the_title', 'PressbooksBook\Filters\add_private_to_title', 10, 2 );
 add_action( 'pb_theme_options_web_add_settings_fields', '\PressbooksBook\Actions\add_lightbox_setting', 10, 2 );
 add_filter( 'pb_theme_options_web_booleans', '\PressbooksBook\Filters\add_lightbox_to_settings' );
 add_action( 'template_redirect', '\PressbooksBook\Actions\redirect_attachment_page' );
+add_action( 'send_headers', '\PressbooksBook\Actions\noindex_downloads' );
 
 if ( is_admin() ) {
 	add_action( 'wp_ajax_text_diff', '\PressbooksBook\Actions\text_diff' );

--- a/functions.php
+++ b/functions.php
@@ -72,6 +72,7 @@ add_action( 'pb_theme_options_web_add_settings_fields', '\PressbooksBook\Actions
 add_filter( 'pb_theme_options_web_booleans', '\PressbooksBook\Filters\add_lightbox_to_settings' );
 add_action( 'template_redirect', '\PressbooksBook\Actions\redirect_attachment_page' );
 add_action( 'send_headers', '\PressbooksBook\Actions\noindex_downloads' );
+add_filter( 'robots_txt', '\PressbooksBook\Actions\disallow_downloads_for_robots', 10, 2 );
 
 if ( is_admin() ) {
 	add_action( 'wp_ajax_text_diff', '\PressbooksBook\Actions\text_diff' );

--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -203,9 +203,26 @@ function customizer_colors() {
  *
  * @since 2.30.4
  */
-function noindex_downloads() {
-if ( isset( $_GET['type'] ) && strpos( $_SERVER['REQUEST_URI'], '/open/download' ) !== false ) {
-	header( 'X-Robots-Tag: noindex, nofollow', true );
+function noindex_downloads()
+{
+	if (isset($_GET['type']) && strpos($_SERVER['REQUEST_URI'], '/open/download') !== false) {
+		header('X-Robots-Tag: noindex, nofollow', true);
+	}
+}
+
+/**
+ * Disallow /open/download in robots.txt
+ *
+ * @since 2.30.4
+ *
+ * @param string   $output   The robots.txt output so far.
+ * @param \WP_Query $wp_query The WP_Query instance (passed by reference).
+ *
+ * @return string The modified robots.txt output.
+ */
+function disallow_downloads_for_robots( string $output, \WP_Query $wp_query ): string {
+	$output .= "\nUser-agent: *\nDisallow: /open/download\n";
+	return $output;
 }
 
 /**

--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -204,9 +204,9 @@ function customizer_colors() {
  * @since 2.30.4
  */
 function noindex_downloads() {
-	if ( isset($_GET['type']) && strpos($_SERVER['REQUEST_URI'], '/open/download') !== false ) {
-		header( 'X-Robots-Tag: noindex, nofollow', true );
-	}
+if ( isset( $_GET['type'] ) && strpos( $_SERVER['REQUEST_URI'], '/open/download' ) !== false ) {
+	header( 'X-Robots-Tag: noindex, nofollow', true );
+}
 
 /**
  * Add web theme option for lightbox functionality.

--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -203,8 +203,7 @@ function customizer_colors() {
  *
  * @since 2.30.4
  */
-function noindex_downloads()
-{
+function noindex_downloads() {
 	if (isset($_GET['type']) && strpos($_SERVER['REQUEST_URI'], '/open/download') !== false) {
 		header('X-Robots-Tag: noindex, nofollow', true);
 	}

--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -199,6 +199,16 @@ function customizer_colors() {
 }
 
 /**
+ * Add X-Robots-Tag header to download URLs to prevent indexing by search engines.
+ *
+ * @since 2.30.4
+ */
+function noindex_downloads() {
+	if ( isset($_GET['type']) && strpos($_SERVER['REQUEST_URI'], '/open/download') !== false ) {
+		header( 'X-Robots-Tag: noindex, nofollow', true );
+	}
+
+/**
  * Add web theme option for lightbox functionality.
  *
  * @since 2.4.0

--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -204,8 +204,8 @@ function customizer_colors() {
  * @since 2.30.4
  */
 function noindex_downloads() {
-	if (isset($_GET['type']) && strpos($_SERVER['REQUEST_URI'], '/open/download') !== false) {
-		header('X-Robots-Tag: noindex, nofollow', true);
+	if ( isset( $_GET['type'] ) && strpos( $_SERVER['REQUEST_URI'], '/open/download' ) !== false ) {
+		header( 'X-Robots-Tag: noindex, nofollow', true );
 	}
 }
 

--- a/partials/content-cover-book-header.php
+++ b/partials/content-cover-book-header.php
@@ -55,7 +55,7 @@ use function \Pressbooks\Image\attachment_id_from_url;
 			$option      = get_option( 'pbt_redistribute_settings', [ 'latest_files_public' => 0 ] );
 			if ( ! empty( $files ) && ( ! empty( $site_option['allow_redistribution'] ) ) && ( ! empty( $option['latest_files_public'] ) ) ) {
 				?>
-				<div class="book-header__cover__downloads dropdown">
+				<div class="book-header__cover__downloads dropdown" data-nosnippet>
 
 					<p><?php esc_html_e( 'Download this book', 'pressbooks-book' ); ?></p>
 					<ul>


### PR DESCRIPTION
Filter robots.txt to stop bots from opening `open/download` links. Add no-index rules to download links and data-nosnippet to div containing the links on book homepage. Addresses #1381 