### PR TITLE
feat: add content only query params

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -49,6 +49,14 @@ foreach ( $includes as $include ) {
 	require get_template_directory() . "/inc/$include/namespace.php";
 }
 
+// Enable content-only mode via query parameter for external services (e.g., link checkers)
+add_filter( 'pb_content_only', function ( $content_only ) {
+	if ( isset( $_GET['content_only'] ) && $_GET['content_only'] ) {
+		return true;
+	}
+	return $content_only;
+} );
+
 add_action( 'init', '\PressbooksBook\Actions\register_h5p_listing_page' );
 add_action( 'wp_enqueue_scripts', '\PressbooksBook\Actions\enqueue_h5p_listing_bootstrap_files' );
 add_action( 'pb_cache_delete', '\PressbooksBook\Actions\delete_cached_contents' );

--- a/single.php
+++ b/single.php
@@ -13,8 +13,7 @@ if ( have_posts() ) {
 	while ( have_posts() ) :
 		the_post();
 		get_header();
-		$initial_content_only = isset( $_GET['content_only'] ) && $_GET['content_only'];
-		$display_content_only = apply_filters( 'pb_content_only', $initial_content_only );
+		$display_content_only = apply_filters( 'pb_content_only', false );
 		if ( is_book_public() ) :
 			$web_options  = get_option( 'pressbooks_theme_options_web' );
 			$number       = ( $post->post_type === 'chapter' ) ? pb_get_chapter_number( $post->ID ) : false;

--- a/single.php
+++ b/single.php
@@ -13,7 +13,8 @@ if ( have_posts() ) {
 	while ( have_posts() ) :
 		the_post();
 		get_header();
-		$display_content_only = apply_filters( 'pb_content_only', false );
+		$initial_content_only = isset( $_GET['content_only'] ) && $_GET['content_only'];
+		$display_content_only = apply_filters( 'pb_content_only', $initial_content_only );
 		if ( is_book_public() ) :
 			$web_options  = get_option( 'pressbooks_theme_options_web' );
 			$number       = ( $post->post_type === 'chapter' ) ? pb_get_chapter_number( $post->ID ) : false;


### PR DESCRIPTION
Allow enabling "content-only" mode via a query parameter, which is useful for external services like our LTI tool or external accessibility scanning service.

**To test:**
1. append `?content_only=1` to any page URL
2. observe that you only see page content and not extra header/footer/nav elements