### PR TITLE
feat: prince 16 support

### DIFF
--- a/assets/book/typography/styles/_EncodeSansFont.scss
+++ b/assets/book/typography/styles/_EncodeSansFont.scss
@@ -21,12 +21,12 @@
   font-family: 'EncodeSans';
   src: url('fonts/EncodeSans-ExtraBold.ttf') format('truetype');
   font-style: normal;
-  font-weight: bolder;
+  font-weight: 800;
 }
 
 @font-face {
   font-family: 'EncodeSans';
   src: url('fonts/EncodeSans-Light.ttf') format('truetype');
   font-style: normal;
-  font-weight: lighter;
+  font-weight: 300;
 }

--- a/assets/book/typography/styles/_RalewayFont.scss
+++ b/assets/book/typography/styles/_RalewayFont.scss
@@ -63,13 +63,13 @@
 @font-face {
   font-family: 'Raleway';
   src: url('fonts/Raleway-Light.ttf') format('truetype');
-  font-weight: lighter;
+  font-weight: 300;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Raleway';
   src: url('fonts/Raleway-LightItalic.ttf') format('truetype');
-  font-weight: lighter;
+  font-weight: 300;
   font-style: italic;
 }


### PR DESCRIPTION
This pull request standardizes the font-weight values for custom fonts in the project's SCSS files. Instead of using keywords like `bolder` and `lighter`, the changes use explicit numeric values for better consistency and CSS compatibility.

Font weight standardization:

* Updated `font-weight` for `EncodeSans-ExtraBold` from `bolder` to `800`, and for `EncodeSans-Light` from `lighter` to `300` in `_EncodeSansFont.scss`.
* Updated `font-weight` for `Raleway-Light` and `Raleway-LightItalic` from `lighter` to `300` in `_RalewayFont.scss`.

If we use lighter and bolder (Prince 16 won't load the correct fonts and it will try to load only the light version even is bold)

The problem is where we were using it: inside @font-face descriptors, not as a regular CSS property.

The distinction

```
/* VALID — CSS property on an element */
p {
  font-weight: lighter; /* relative to parent's weight */
}
/* INVALID — @font-face descriptor */
@font-face {
  font-family: "Raleway";
  src: url("Raleway-Light.ttf");
  font-weight: lighter; /* NOT allowed here */
}
```

In an `@font-face rule`, font-weight is a descriptor, not a property. It tells the browser: "this font file corresponds to this specific weight." The spec only allows absolute values here — normal, bold, or numeric 1-1000. Relative keywords (lighter, bolder) don't make sense because there's no parent element to be relative to.

From the CSS Fonts spec (Section 4.2) (https://www.w3.org/TR/css-fonts-4/#font-prop-desc):

> The meaning of the values for these descriptors are the same as those for the corresponding font properties except that relative keywords are not allowed, [bolder](https://www.w3.org/TR/css-fonts-4/#valdef-font-weight-bolder) and [lighter](https://www.w3.org/TR/css-fonts-4/#valdef-font-weight-lighter). If these descriptors are omitted, initial values are assumed. If specified values are out of range of the accepted values of the property of the same name, the descriptor is treated as a parse error.

Prince 16 adheres better with CSS specification.

This would produce small differences in rendering due the default `font-weight` management (the right one) if we really really want to have exactly the same `font-weight` we would need to tweak weights in the book theme now that are inheriting the right values.


This means exports with tons of `textboxes` could be shifted in **Prince 16** just because the slightly font-weight diff, this also could result in different pages count. (not a big deal in my opinion)

<img width="1576" height="967" alt="image" src="https://github.com/user-attachments/assets/1a323854-b6cb-4989-94bd-9afaadef757a" />

### Related PRs

https://github.com/pressbooks/buckram/pull/411
https://github.com/pressbooks/pressbooks/pull/4428

### Important 

We need to release a new buckram version and pin that version on this PR before merging
