### PR TITLE
fix: improve alt text for logo image

### DIFF
--- a/header.php
+++ b/header.php
@@ -126,7 +126,7 @@
 								wp_get_attachment_image_src( $custom_logo_id, 'logo' )[0],
 								wp_get_attachment_image_srcset( $custom_logo_id, 'large' ),
 								/* translators: %s: name of network */
-								sprintf( __( 'Logo for %s', 'pressbooks-book' ), get_bloginfo( 'name', 'display' ) )
+								sprintf( __( '%s home', 'pressbooks-book' ), get_bloginfo( 'name', 'display' ) )
 							);
 						} else {
 							?>


### PR DESCRIPTION
Change default alt text for logo links. Fix for https://github.com/pressbooks/pressbooks-book/issues/1450

To test:
1. Add a custom logo to the network using the Aldine customizer
2. Change the site title using the Aldine customizer
3. Observe that the alt text for the logo on all book pages now reads `[Site title] home`