### PR TITLE
chore: update class existence check for assets

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@
 /**
  * Ensure dependencies are loaded
  */
-if ( ! class_exists( 'PressbooksMix\Assets' ) ) {
+if ( ! class_exists( 'PressbooksFrontendTools\Assets' ) ) {
 	$composer = get_template_directory() . '/vendor/autoload.php';
 	if ( ! file_exists( $composer ) ) {
 		wp_die(


### PR DESCRIPTION
This pull request updates a dependency check in the `functions.php` file to reference the correct class name. This ensures the code properly verifies that the required assets class from the `PressbooksFrontendTools` namespace is loaded, rather than the old `PressbooksMix` namespace. 

- Dependency Management:
  * Updated the class existence check from `PressbooksMix\Assets` to `PressbooksFrontendTools\Assets` to align with the current namespace and prevent potential loading issues.