### PR TITLE
fix: links accessibility

### DIFF
--- a/.github/workflows/ensure-npm-build.yml
+++ b/.github/workflows/ensure-npm-build.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   update-npm-build:
     uses: pressbooks/reusable-workflows/.github/workflows/npm-build.yml@main
+    secrets:
+      PAT_FOR_GITHUB_ACTIONS: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"aetna": "^1.1.0",
-				"buckram": "^1.10.0",
+				"buckram": "^1.10.2",
 				"details-element-polyfill": "^2.4.0",
 				"lity": "^2.4.0",
 				"sharer.js": "^0.5.1",
@@ -4566,9 +4566,9 @@
 			"license": "ISC"
 		},
 		"node_modules/buckram": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/buckram/-/buckram-1.10.0.tgz",
-			"integrity": "sha512-003guzBa5P+MX4T3iIxDC5HpJu5dVNoj3LK+MIrvrjca0R3Tgw+4JXgw19ehjFFnpRaDqhi9FIPMtgktyUvdVQ==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/buckram/-/buckram-1.10.2.tgz",
+			"integrity": "sha512-Wc8eCK9tRHeUHArLQo4K+ksOJ6IQbOaZmOQTFX2F+ROWF8Vzi3SmRcjTCTyaT8i4G4aYLwth6Heq+sjm1gsaUg==",
 			"license": "GPL-3.0-or-later",
 			"engines": {
 				"node": ">= 22"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"dependencies": {
 		"aetna": "^1.1.0",
-		"buckram": "^1.10.0",
+		"buckram": "^1.10.2",
 		"details-element-polyfill": "^2.4.0",
 		"lity": "^2.4.0",
 		"sharer.js": "^0.5.1",

--- a/packages/buckram/CHANGELOG.md
+++ b/packages/buckram/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.10.2](https://github.com/pressbooks/buckram/compare/v1.10.1...v1.10.2) (2026-06-25)
+
+
+### Bug Fixes
+
+* keep wrapped links clickable and single-tagged in PDF export ([#425](https://github.com/pressbooks/buckram/issues/425)) ([b5fd4cc](https://github.com/pressbooks/buckram/commit/b5fd4cc38be3583069efaeea462832298712bb46))
+
+## [1.10.1](https://github.com/pressbooks/buckram/compare/v1.10.0...v1.10.1) (2026-06-16)
+
+
+### Bug Fixes
+
+* links should be underlined by default for all formats (fix [#419](https://github.com/pressbooks/buckram/issues/419)) ([#420](https://github.com/pressbooks/buckram/issues/420)) ([c0653ad](https://github.com/pressbooks/buckram/commit/c0653ad45a6a6dff99089623eb2cf4ed5901323a))
+* prevent hyphenation within links (see pressbooks/pressbooks[#2512](https://github.com/pressbooks/buckram/issues/2512)) ([#422](https://github.com/pressbooks/buckram/issues/422)) ([be1fb8f](https://github.com/pressbooks/buckram/commit/be1fb8f199e7f477962eec969f558561711806c1))
+
 ## [1.10.0](https://github.com/pressbooks/buckram/compare/v1.9.1...v1.10.0) (2026-05-06)
 
 

--- a/packages/buckram/assets/styles/components/elements/_links.scss
+++ b/packages/buckram/assets/styles/components/elements/_links.scss
@@ -10,11 +10,24 @@
 
 @if $type != 'web' {
   a {
+    hyphens: none;
     text-decoration: if-map-get($link-text-decoration, $type);
   }
 }
 
 @if $type == 'prince' {
+  // Render each anchor as a single atomic box so PrinceXML emits one PDF link
+  // rectangle (and one OBJR tag) for the whole anchor, even when a long URL
+  // wraps across lines. This keeps the entire URL clickable
+  // (pressbooks/pressbooks#2512) and stops screen readers repeating the link
+  // from duplicate OBJR tags (pressbooks/private#2394). max-width and
+  // overflow-wrap let the URL wrap inside the box instead of overflowing.
+  a {
+    display: inline-block;
+    max-width: 100%;
+    overflow-wrap: break-word;
+  }
+
   .print a {
     text-decoration: $link-text-decoration-print;
   }

--- a/packages/buckram/assets/styles/variables/_elements.scss
+++ b/packages/buckram/assets/styles/variables/_elements.scss
@@ -1280,7 +1280,7 @@ $sup-line-height: $sup-sub-line-height !default;
 /// Text decoration for `<a>` elements.
 /// @type String
 $link-text-decoration: (
-  epub: none,
+  epub: underline,
   prince: underline,
   web: underline
 ) !default;

--- a/packages/buckram/package.json
+++ b/packages/buckram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buckram",
-  "version": "1.10.0",
+  "version": "1.10.2",
   "description": "Opinionated SCSS components for books (web, EPUB and PDF).",
   "scripts": {
     "build": "composer install && composer test",


### PR DESCRIPTION
This pull request updates the `buckram` package to version 1.10.2, bringing in several bug fixes and improvements related to link rendering across different formats. The most important changes are grouped below.

**Dependency Update:**

* Updated the `buckram` dependency in the root `package.json` to version `^1.10.2`, ensuring the latest bug fixes and features are included.
* Bumped the version of `buckram` itself to `1.10.2` in its `package.json`.

**Link Rendering Improvements:**

* Changed default link styling so that links are underlined in EPUB output, improving consistency and accessibility.
* Prevented hyphenation within links for non-web outputs, ensuring links remain readable and unbroken.
* For PrinceXML (PDF export), made anchors render as single atomic boxes, keeping wrapped links fully clickable and preventing duplicate accessibility tags.

**Documentation:**

* Added detailed changelog entries for versions 1.10.1 and 1.10.2, documenting all recent bug fixes related to link rendering and accessibility.