### PR TITLE
chore: bump buckram version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 vendor
+packages/buckram/.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"aetna": "^1.1.0",
-				"buckram": "^1.10.3",
+				"buckram": "^1.10.4",
 				"details-element-polyfill": "^2.4.0",
 				"lity": "^2.4.0",
 				"sharer.js": "^0.5.1",
@@ -4566,9 +4566,9 @@
 			"license": "ISC"
 		},
 		"node_modules/buckram": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/buckram/-/buckram-1.10.3.tgz",
-			"integrity": "sha512-qi3tBd8OyLWRpPuL0zrnAGD6mvXgaTdXMsDmBeOEHdUG2o/bQIYXaUdOT49qGwpdbugoz5+TgtFD5Szf3Z7QqA==",
+			"version": "1.10.4",
+			"resolved": "https://registry.npmjs.org/buckram/-/buckram-1.10.4.tgz",
+			"integrity": "sha512-hkIV7KI9kIEouHbIKPaHKirNZoQjsWD0fMkX5RuI0vXvMWNjH+5wLgb8qn7nMMfuY2sharOCWhM9oFLNENTlcg==",
 			"license": "GPL-3.0-or-later",
 			"engines": {
 				"node": ">= 22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"aetna": "^1.1.0",
-				"buckram": "^1.10.2",
+				"buckram": "^1.10.3",
 				"details-element-polyfill": "^2.4.0",
 				"lity": "^2.4.0",
 				"sharer.js": "^0.5.1",
@@ -4566,9 +4566,9 @@
 			"license": "ISC"
 		},
 		"node_modules/buckram": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/buckram/-/buckram-1.10.2.tgz",
-			"integrity": "sha512-Wc8eCK9tRHeUHArLQo4K+ksOJ6IQbOaZmOQTFX2F+ROWF8Vzi3SmRcjTCTyaT8i4G4aYLwth6Heq+sjm1gsaUg==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/buckram/-/buckram-1.10.3.tgz",
+			"integrity": "sha512-qi3tBd8OyLWRpPuL0zrnAGD6mvXgaTdXMsDmBeOEHdUG2o/bQIYXaUdOT49qGwpdbugoz5+TgtFD5Szf3Z7QqA==",
 			"license": "GPL-3.0-or-later",
 			"engines": {
 				"node": ">= 22"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"dependencies": {
 		"aetna": "^1.1.0",
-		"buckram": "^1.10.2",
+		"buckram": "^1.10.3",
 		"details-element-polyfill": "^2.4.0",
 		"lity": "^2.4.0",
 		"sharer.js": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"dependencies": {
 		"aetna": "^1.1.0",
-		"buckram": "^1.10.3",
+		"buckram": "^1.10.4",
 		"details-element-polyfill": "^2.4.0",
 		"lity": "^2.4.0",
 		"sharer.js": "^0.5.1",

--- a/packages/buckram/CHANGELOG.md
+++ b/packages/buckram/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.10.3](https://github.com/pressbooks/buckram/compare/v1.10.2...v1.10.3) (2026-07-22)
+
+
+### Bug Fixes
+
+* rendering links indent ([#433](https://github.com/pressbooks/buckram/issues/433)) ([7c5ace3](https://github.com/pressbooks/buckram/commit/7c5ace38a06bda84d36a500b1be26d6df0e6383f))
+
 ## [1.10.2](https://github.com/pressbooks/buckram/compare/v1.10.1...v1.10.2) (2026-06-25)
 
 

--- a/packages/buckram/CHANGELOG.md
+++ b/packages/buckram/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.10.4](https://github.com/pressbooks/buckram/compare/v1.10.3...v1.10.4) (2026-07-23)
+
+
+### Bug Fixes
+
+* toc display with inline block for a single clickable OBJR ([#437](https://github.com/pressbooks/buckram/issues/437)) ([7e62a6a](https://github.com/pressbooks/buckram/commit/7e62a6a6de8b47bb771e5555363a6b3da5680d80))
+
 ## [1.10.3](https://github.com/pressbooks/buckram/compare/v1.10.2...v1.10.3) (2026-07-22)
 
 

--- a/packages/buckram/assets/styles/components/elements/_links.scss
+++ b/packages/buckram/assets/styles/components/elements/_links.scss
@@ -16,16 +16,11 @@
 }
 
 @if $type == 'prince' {
-  // Render each anchor as a single atomic box so PrinceXML emits one PDF link
-  // rectangle (and one OBJR tag) for the whole anchor, even when a long URL
-  // wraps across lines. This keeps the entire URL clickable
-  // (pressbooks/pressbooks#2512) and stops screen readers repeating the link
-  // from duplicate OBJR tags (pressbooks/private#2394). max-width and
-  // overflow-wrap let the URL wrap inside the box instead of overflowing.
   a {
     display: inline-block;
-    max-width: 100%;
     overflow-wrap: break-word;
+    text-indent: 0;
+    max-width: 100%;
   }
 
   .print a {

--- a/packages/buckram/assets/styles/components/toc/_generic.scss
+++ b/packages/buckram/assets/styles/components/toc/_generic.scss
@@ -26,6 +26,7 @@
 
     a {
       border: 0;
+      width: 100%;
     }
 
     .toc-chapter-title {

--- a/packages/buckram/package.json
+++ b/packages/buckram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buckram",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Opinionated SCSS components for books (web, EPUB and PDF).",
   "scripts": {
     "build": "composer install && composer test",

--- a/packages/buckram/package.json
+++ b/packages/buckram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buckram",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Opinionated SCSS components for books (web, EPUB and PDF).",
   "scripts": {
     "build": "composer install && composer test",


### PR DESCRIPTION
Inline block FOR TOC fix

https://github.com/pressbooks/buckram/releases/tag/v1.10.4