### PR TITLE
feat: WP 7.x support

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -590,7 +590,7 @@ function social_media_enabled() {
 function is_book_public() {
 	global $blog_id;
 	$blog_public = absint( get_option( 'blog_public' ) );
-	if ( $blog_public === 1 || $blog_public === 0 && current_user_can_for_blog( $blog_id, 'read' ) ) {
+	if ( $blog_public === 1 || $blog_public === 0 && current_user_can_for_site( $blog_id, 'read' ) ) {
 		return true;
 	}
 	return false;

--- a/partials/content-toc.php
+++ b/partials/content-toc.php
@@ -10,8 +10,8 @@ if ( ! isset( $book_subsections ) ) {
 
 // Setup TOC specific variables
 global $blog_id;
-$can_read = current_user_can_for_blog( $blog_id, 'read' );
-$can_read_private = current_user_can_for_blog( $blog_id, 'read_private_posts' );
+$can_read = current_user_can_for_site( $blog_id, 'read' );
+$can_read_private = current_user_can_for_site( $blog_id, 'read_private_posts' );
 $permissive_private_content = (int) get_option( 'permissive_private_content', 0 );
 $options = get_option( 'pressbooks_theme_options_global' );
 $part_numbers = $options['chapter_numbers'] ?? false; ?>

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -46,6 +46,27 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'Word', $output );
 	}
 
+	/**
+	 * Characterization test guarding is_book_public() across the
+	 * current_user_can_for_blog() -> current_user_can_for_site() swap (the
+	 * former was deprecated in WP 6.7.0). Covers both branches: a public book
+	 * is public to anyone; a private book is public only to a user who can read.
+	 *
+	 * @group wp7
+	 */
+	function test_is_book_public_reflects_blog_public_and_read_capability() {
+		// Public book: public regardless of the current user.
+		update_option( 'blog_public', 1 );
+		wp_set_current_user( 0 );
+		$this->assertTrue( is_book_public() );
+
+		// Private book: public only via the per-site read-capability check.
+		update_option( 'blog_public', 0 );
+		$admin = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin );
+		$this->assertTrue( is_book_public() );
+	}
+
 	function test_license_to_icons() {
 		$output = license_to_icons( 'cc-by' );
 		$this->assertEquals( '<svg class="icon" style="fill: currentColor" role="presentation"><use href="#cc" /></svg><svg class="icon" style="fill: currentColor" role="presentation"><use href="#cc-by" /></svg>', $output );


### PR DESCRIPTION
Issue pressbooks/pressbooks#4523

Part of the WordPress 7.0 compatibility program.

### Summary
Replaces `current_user_can_for_blog()` — deprecated in WordPress **6.7.0** — with its
documented drop-in replacement `current_user_can_for_site()` (identical signature).

### Why
The WP 7.0 audit of this theme found no regressions, but the deprecation sniff flagged
this pre-existing deprecated-API usage. The replacement is 1:1: in current WordPress,
`current_user_can_for_blog()` is a silent alias that simply calls
`current_user_can_for_site()`, so behavior is unchanged.

### Changes
- `inc/helpers/namespace.php` — `is_book_public()`
- `partials/content-toc.php` — TOC read / read-private capability checks (×2)

### Testing
- Added a characterization test for `is_book_public()` covering both branches
  (public book; private book + a user who can read) — green before and after the change,
  guarding behavior across the swap (this function had no prior test coverage).
- The `WordPress.WP.DeprecatedFunctions` sniff for this file set goes from 3 findings → 0.
- `composer standards` clean.
- Full suite green, except two **pre-existing, environment-dependent** failures
  (`test_get_source_book_meta`, `test_get_source_book_toc`) that require fetching a remote
  source book — they fail identically on `dev` without this change and are unrelated to it.